### PR TITLE
Update readme and fix call to getModuleInfo to use the module name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,14 +78,16 @@ Here are the settings you can place in your `boxlang.json` file:
 {
 	"modules" : {
 		"bxai" : {
-			// The provider to use: openai, deepseek, gemini, grok, perplexity, etc
-			provider : "openai",
-			// The API Key for the provider
-			apiKey : "",
-			// The default request params to use when calling a provider
-			// Ex: { temperature: 0.5, max_tokens: 100, model: "gpt-3.5-turbo" }
-			defaultParams = {
-				// model: "gpt-3.5-turbo"
+			"settings": { 
+				// The provider to use: openai, deepseek, gemini, grok, perplexity, etc
+				provider : "openai",
+				// The API Key for the provider
+				apiKey : "",
+				// The default request params to use when calling a provider
+				// Ex: { temperature: 0.5, max_tokens: 100, model: "gpt-3.5-turbo" }
+				defaultParams = {
+					// model: "gpt-3.5-turbo"
+				}
 			}
 		}
 	}

--- a/src/main/bx/bifs/aiChat.bx
+++ b/src/main/bx/bifs/aiChat.bx
@@ -11,7 +11,7 @@ class {
 		logResponse : false,
 		logRequest : false
 	}
-	static MODULE_SETTINGS = getModuleInfo( "bx-ai" ).settings;
+	static MODULE_SETTINGS = getModuleInfo( "bxai" ).settings;
 
 	/**
 	 * Inject the following references into the class

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -38,7 +38,7 @@ abstract class implements="IService" {
 	 * Constants
 	 */
 	static {
-		final settings = getModuleInfo( "bx-ai" ).settings
+		final settings = getModuleInfo( "bxai" ).settings
 	}
 
 	/**


### PR DESCRIPTION
# Description

Update readme to include the settings nesting thats required and fixed the call to getModuleInfo to use the module name of bxai instead of bx-ai.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
