### PR TITLE
Fix: MCP requestId null scope crash on JSON-RPC notifications

### DIFF
--- a/src/main/bx/models/mcp/MCPServer.bx
+++ b/src/main/bx/models/mcp/MCPServer.bx
@@ -1283,7 +1283,7 @@ class {
 		var thisRequest = isStruct( arguments.requestBody )
 			? arguments.requestBody
 			: jsonDeserialize( arguments.requestBody )
-		var requestId = thisRequest.id ?: javacast( "null", "" )
+		var requestId = structKeyExists( thisRequest, "id" ) ? thisRequest.id : ""
 		var method = thisRequest.method ?: ""
 		var params = thisRequest.params ?: {}
 
@@ -1500,13 +1500,13 @@ class {
 	 *
 	 * @return The JSON-RPC response struct
 	 */
-	private struct function buildSuccessResponse( any id, struct result = {} ) {
+	private struct function buildSuccessResponse( any id = "", struct result = {} ) {
 		var response = {
 			"jsonrpc": "2.0",
 			"result": arguments.result
 		}
 
-		if ( !isNull( arguments.id ) ) {
+		if ( len( arguments.id ) ) {
 			response[ "id" ] = arguments.id
 		}
 
@@ -1522,7 +1522,7 @@ class {
 	 *
 	 * @return The JSON-RPC error response struct
 	 */
-	private struct function buildErrorResponse( any id, required numeric code, required string message ) {
+	private struct function buildErrorResponse( any id = "", required numeric code, required string message ) {
 		var response = {
 			"jsonrpc": "2.0",
 			"error": {
@@ -1531,7 +1531,7 @@ class {
 			}
 		}
 
-		if ( !isNull( arguments.id ) ) {
+		if ( len( arguments.id ) ) {
 			response[ "id" ] = arguments.id
 		}
 

--- a/src/main/bx/models/mcp/MCPServer.bx
+++ b/src/main/bx/models/mcp/MCPServer.bx
@@ -1283,7 +1283,7 @@ class {
 		var thisRequest = isStruct( arguments.requestBody )
 			? arguments.requestBody
 			: jsonDeserialize( arguments.requestBody )
-		var requestId = ( structKeyExists( thisRequest, "id" ) && !isNull( thisRequest.id ) ) ? thisRequest.id : ""
+		var requestId = thisRequest?.id ?: ""
 		var method = thisRequest.method ?: ""
 		var params = thisRequest.params ?: {}
 
@@ -1506,7 +1506,7 @@ class {
 			"result": arguments.result
 		}
 
-		if ( arguments.id != "" ) {
+		if ( arguments.id.len() ) {
 			response[ "id" ] = arguments.id
 		}
 
@@ -1531,7 +1531,7 @@ class {
 			}
 		}
 
-		if ( arguments.id != "" ) {
+		if ( arguments.id.len() ) {
 			response[ "id" ] = arguments.id
 		}
 

--- a/src/main/bx/models/mcp/MCPServer.bx
+++ b/src/main/bx/models/mcp/MCPServer.bx
@@ -1283,7 +1283,7 @@ class {
 		var thisRequest = isStruct( arguments.requestBody )
 			? arguments.requestBody
 			: jsonDeserialize( arguments.requestBody )
-		var requestId = structKeyExists( thisRequest, "id" ) ? thisRequest.id : ""
+		var requestId = ( structKeyExists( thisRequest, "id" ) && !isNull( thisRequest.id ) ) ? thisRequest.id : ""
 		var method = thisRequest.method ?: ""
 		var params = thisRequest.params ?: {}
 
@@ -1495,7 +1495,7 @@ class {
 	/**
 	 * Build a JSON-RPC success response
 	 *
-	 * @id The request ID
+	 * @id The request ID. Empty string means the request was a notification (no id); omitted from response.
 	 * @result The result data
 	 *
 	 * @return The JSON-RPC response struct
@@ -1506,7 +1506,7 @@ class {
 			"result": arguments.result
 		}
 
-		if ( len( arguments.id ) ) {
+		if ( arguments.id != "" ) {
 			response[ "id" ] = arguments.id
 		}
 
@@ -1516,7 +1516,7 @@ class {
 	/**
 	 * Build a JSON-RPC error response
 	 *
-	 * @id The request ID, may be null
+	 * @id The request ID. Empty string means the request was a notification (no id); omitted from response.
 	 * @code The error code
 	 * @message The error message
 	 *
@@ -1531,7 +1531,7 @@ class {
 			}
 		}
 
-		if ( len( arguments.id ) ) {
+		if ( arguments.id != "" ) {
 			response[ "id" ] = arguments.id
 		}
 

--- a/src/main/bx/models/providers/BedrockService.bx
+++ b/src/main/bx/models/providers/BedrockService.bx
@@ -94,19 +94,19 @@ class extends = "BaseService"{
 	 *
 	 *         OR a simple string for backward compatibility (treated as modelId)
 	 *
-	 * @config A struct containing: region, awsAccessKeyId, awsSecretAccessKey, awsSessionToken (optional), modelId (optional)
+	 * @options A struct containing: region, awsAccessKeyId, awsSecretAccessKey, awsSessionToken (optional), modelId (optional)
 	 *
 	 * @return The service instance
 	 */
-	IAiService function configure( required any config ){
-		if ( isSimpleValue( arguments.config ) ) {
+	IAiService function configure( required any options ){
+		if ( isSimpleValue( arguments.options ) ) {
 			// If a simple string is passed, treat it as model ID for compatibility
-			variables.modelId = arguments.config;
-		} else if ( isStruct( arguments.config ) ) {
+			variables.modelId = arguments.options;
+		} else if ( isStruct( arguments.options ) ) {
 			// Check if credentials are nested inside apiKey (from aiChat/aiService flow)
-			var credSource = arguments.config;
-			if ( arguments.config.keyExists( "apiKey" ) && isStruct( arguments.config.apiKey ) ) {
-				credSource = arguments.config.apiKey;
+			var credSource = arguments.options;
+			if ( arguments.options.keyExists( "apiKey" ) && isStruct( arguments.options.apiKey ) ) {
+				credSource = arguments.options.apiKey;
 			}
 
 			// Configure with struct of settings - check both top-level and apiKey nested
@@ -123,11 +123,11 @@ class extends = "BaseService"{
 				variables.awsSessionToken = credSource.awsSessionToken;
 			}
 			// These remain at top level
-			if ( arguments.config.keyExists( "modelId" ) ) {
-				variables.modelId = arguments.config.modelId;
+			if ( arguments.options.keyExists( "modelId" ) ) {
+				variables.modelId = arguments.options.modelId;
 			}
-			if ( arguments.config.keyExists( "model" ) ) {
-				variables.params.model = arguments.config.model;
+			if ( arguments.options.keyExists( "model" ) ) {
+				variables.params.model = arguments.options.model;
 			}
 		}
 

--- a/src/main/bx/models/providers/DockerModelRunnerService.bx
+++ b/src/main/bx/models/providers/DockerModelRunnerService.bx
@@ -79,21 +79,21 @@ class extends = "OpenAICompatibleService"{
 	 *   - Struct: Configuration options (see OpenAICompatibleService.configure) plus:
 	 *     - useHostURL: Boolean to use localhost URL instead of Docker internal
 	 *
-	 * @config Can be:
+	 * @options Can be:
 	 *
 	 * @return The service instance for chaining
 	 */
 		@override
-	IAiService function configure( required any config ){
+	IAiService function configure( required any options ){
 		// Handle Docker-specific useHostURL option before calling parent
 		if (
-			isStruct( arguments.config ) && arguments.config.keyExists( "useHostURL" ) && arguments.config.useHostURL
+			isStruct( arguments.options ) && arguments.options.keyExists( "useHostURL" ) && arguments.options.useHostURL
 		) {
-			arguments.config.baseURL = static.HOST_BASE_URL;
+			arguments.options.baseURL = static.HOST_BASE_URL;
 		}
 
 		// Delegate to parent for standard configuration
-		return super.configure( arguments.config );
+		return super.configure( arguments.options );
 	}
 
 	/**

--- a/src/main/bx/models/providers/OpenAICompatibleService.bx
+++ b/src/main/bx/models/providers/OpenAICompatibleService.bx
@@ -77,7 +77,7 @@ class extends="BaseService" {
 	/**
 	 * Configure the service with options
 	 *
-	 * @config Can be:
+	 * @options Can be:
 	 *   - String: API key (optional, empty string for no auth)
 	 *   - Struct: Configuration options including:
 	 *     - apiKey: API key for authenticated endpoints (optional)
@@ -90,24 +90,24 @@ class extends="BaseService" {
 	 * @return The service instance for chaining
 	 */
 	@override
-	IAiService function configure( required any config ) {
+	IAiService function configure( required any options ) {
 		// Delegate to parent for standard configuration (handles apiKey, model extraction to params)
-		super.configure( arguments.config )
+		super.configure( arguments.options )
 
 		// Store baseURL for reference if provided
-		if ( isStruct( arguments.config ) && arguments.config.keyExists( "baseURL" ) && len( arguments.config.baseURL ) ) {
-			variables.baseURL = arguments.config.baseURL.trim()
+		if ( isStruct( arguments.options ) && arguments.options.keyExists( "baseURL" ) && len( arguments.options.baseURL ) ) {
+			variables.baseURL = arguments.options.baseURL.trim()
 			variables.chatURL = variables.baseURL & "/chat/completions"
 			variables.embeddingsURL = variables.baseURL & "/embeddings"
 		}
 
 		// Allow direct URL overrides
-		if ( isStruct( arguments.config ) ) {
-			if ( arguments.config.keyExists( "chatURL" ) && len( arguments.config.chatURL ) ) {
-				variables.chatURL = arguments.config.chatURL.trim()
+		if ( isStruct( arguments.options ) ) {
+			if ( arguments.options.keyExists( "chatURL" ) && len( arguments.options.chatURL ) ) {
+				variables.chatURL = arguments.options.chatURL.trim()
 			}
-			if ( arguments.config.keyExists( "embeddingsURL" ) && len( arguments.config.embeddingsURL ) ) {
-				variables.embeddingsURL = arguments.config.embeddingsURL.trim()
+			if ( arguments.options.keyExists( "embeddingsURL" ) && len( arguments.options.embeddingsURL ) ) {
+				variables.embeddingsURL = arguments.options.embeddingsURL.trim()
 			}
 		}
 

--- a/src/test/java/ortus/boxlang/ai/mcp/mcpServerTest.java
+++ b/src/test/java/ortus/boxlang/ai/mcp/mcpServerTest.java
@@ -1512,4 +1512,27 @@ public class mcpServerTest extends BaseIntegrationTest {
 		assertThat( variables.get( Key.of( "bodyLimit" ) ) ).isEqualTo( 1000 );
 	}
 
+	@Test
+	@DisplayName( "Notification without id does not throw and response omits id" )
+	public void testNotificationWithoutId() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "notificationTest" )
+				// JSON-RPC notification: no "id" key at all
+				result = myServer.handleRequest( {
+					"jsonrpc": "2.0",
+					"method": "ping"
+				} )
+				hasId = structKeyExists( result, "id" )
+				hasJsonrpc = structKeyExists( result, "jsonrpc" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "hasId" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "hasJsonrpc" ) ) ).isEqualTo( true );
+	}
+
 }


### PR DESCRIPTION
# Description

Fix MCP `requestId` null scope crash when handling JSON-RPC notifications (requests without an `id` field).

When a JSON-RPC request omits the `id` field (valid per JSON-RPC 2.0 spec for notifications like `notifications/initialized`), `javacast("null", "")` creates a true null that disappears from BoxLang's local scope. All subsequent references to `requestId` in `handleRequest()` then throw: `The requested key [requestId] was not located in any scope or it's undefined`.

The fix replaces `javacast("null", "")` with `structKeyExists()` + empty string fallback, and updates `buildSuccessResponse()`/`buildErrorResponse()` to use `len()` checks with default parameter values.

Fixes #143

## Jira/Github Issues

- https://github.com/ortus-boxlang/bx-ai/issues/143

## Type of change

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
