### PR TITLE
Add Image I/O System, includes Image I/O with OpenAI Provider

### DIFF
--- a/src/main/bx/bifs/aiChat.bx
+++ b/src/main/bx/bifs/aiChat.bx
@@ -18,7 +18,7 @@
 class {
 
 	static {
-		final VALID_RESPONSE_FORMATS = [ "single", "all", "raw", "json", "xml" ]
+		final VALID_RESPONSE_FORMATS = [ "single", "all", "raw", "json", "xml", "image" ]
 		final DEFAULT_OPTIONS = {
 			returnFormat : "single",  // aiChat() defaults to single for convenience
 		}
@@ -50,7 +50,8 @@ class {
 	 * <li>logResponseToConsole:boolean - Log the response to the console. The default is false</li>
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>
 	 * <li>logRequestToConsole:boolean - Log the request to the console. The default is false</li>
-	 * <li>returnFormat:string - The return format of the response. The default is "single" message. Valid formats are: "single", "all", "raw", "json", "xml"</li>
+	 * <li>returnFormat:string - The return format of the response. The default is "single" message. Valid formats are: "single", "all", "raw", "json", "xml", "image"</li>
+	 * <li>images:array - Optional base64-encoded images to include in the request (OpenAI Response API mode).</li>
 	 * </ul>
 	 *
 	 * @messages The messages to pass into the required model. This depends on the provider. It can be a simple string, a struct representing a message or an array of messages or an actual AiMessage object

--- a/src/main/bx/bifs/aiChat.bx
+++ b/src/main/bx/bifs/aiChat.bx
@@ -51,7 +51,7 @@ class {
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>
 	 * <li>logRequestToConsole:boolean - Log the request to the console. The default is false</li>
 	 * <li>returnFormat:string - The return format of the response. The default is "single" message. Valid formats are: "single", "all", "raw", "json", "xml", "image"</li>
-	 * <li>images:array - Optional base64-encoded images to include in the request (OpenAI Response API mode).</li>
+	 * <li>images:array - Optional base64-encoded images to include in the request.</li>
 	 * </ul>
 	 *
 	 * @messages The messages to pass into the required model. This depends on the provider. It can be a simple string, a struct representing a message or an array of messages or an actual AiMessage object

--- a/src/main/bx/bifs/aiChatAsync.bx
+++ b/src/main/bx/bifs/aiChatAsync.bx
@@ -42,7 +42,8 @@ class extends="aiChat"{
 	 * <li>logResponseToConsole:boolean - Log the response to the console. The default is false</li>
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>
 	 * <li>logRequestToConsole:boolean - Log the request to the console. The default is false</li>
-	 * <li>returnFormat:string - The return format of the response. The default is "single" message. Valid formats are: "single", "all", "raw", "json", "xml"</li>
+	* <li>returnFormat:string - The return format of the response. The default is "single" message. Valid formats are: "single", "all", "raw", "json", "xml", "image"</li>
+	 * <li>images:array - Optional base64-encoded images to include in the request (OpenAI Response API mode).</li>
 	 * </ul>
 	 *
 	 * @messages The messages to pass into the required model. This depends on the provider. It can be a simple string, a struct representing a message or an array of messages or an actual AiMessage object

--- a/src/main/bx/bifs/aiChatAsync.bx
+++ b/src/main/bx/bifs/aiChatAsync.bx
@@ -43,7 +43,7 @@ class extends="aiChat"{
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>
 	 * <li>logRequestToConsole:boolean - Log the request to the console. The default is false</li>
 	* <li>returnFormat:string - The return format of the response. The default is "single" message. Valid formats are: "single", "all", "raw", "json", "xml", "image"</li>
-	 * <li>images:array - Optional base64-encoded images to include in the request (OpenAI Response API mode).</li>
+	 * <li>images:array - Optional base64-encoded images to include in the request.</li>
 	 * </ul>
 	 *
 	 * @messages The messages to pass into the required model. This depends on the provider. It can be a simple string, a struct representing a message or an array of messages or an actual AiMessage object

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -33,6 +33,7 @@ class {
 		struct options = {},
 		string outputPath = "",
 		string format = "png"
+		
 	) {
 		// Ensure we request image output
 		var effectiveOptions = arguments.options;
@@ -43,16 +44,7 @@ class {
 
 		// Optionally write to disk
 		if( arguments.outputPath.len() ){
-			var payload = toString( base64 );
-			// Strip data URI prefix if present
-			if( payload.startsWith( "data:" ) ){
-				var parts = payload.listToArray( "," );
-				if( parts.len() > 1 ){
-					payload = parts[ 1 ];
-				}
-			}
-
-			var bytes = toBinary( payload );
+			var bytes = toBinary( toString(base64) );
 			fileWrite( arguments.outputPath, bytes );
 		}
 

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -21,14 +21,14 @@ class {
 	/**
 	 * Generate an image and return the base64 payload.
 	 *
-	 * @prompt The prompt or message to send to the model
+	 * @messages The prompt or message to send to the model
 	 * @params Provider-specific parameters (model, temperature, etc.)
 	 * @options Request options (timeout, logging, etc.)
 	 * @outputPath Optional file path to write the decoded image bytes
 	 * @format Optional output format (jpeg, png, svg). Only used when writing to disk.
 	 */
 	function invoke(
-		required any prompt,
+		required any messages,
 		struct params = {},
 		struct options = {},
 		string outputPath = "",
@@ -39,7 +39,7 @@ class {
 		effectiveOptions.returnFormat = "image";
 
 		// Request the base64 image
-		var base64 = aiChat( arguments.prompt, arguments.params, effectiveOptions );
+		var base64 = aiChat( arguments.messages, arguments.params, effectiveOptions );
 
 		// Optionally write to disk
 		if( arguments.outputPath.len() ){

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -53,7 +53,7 @@ class {
 			}
 
 			var bytes = toBinary( payload );
-			fileWriteBinary( arguments.outputPath, bytes );
+			fileWrite( arguments.outputPath, bytes );
 		}
 
 		return base64;

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -1,0 +1,62 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * ----------------------------------------------------------------------------------
+ * Create an image using the OpenAI Responses API.
+ * This is a convenience wrapper around aiChat() with returnFormat="image".
+ */
+@BoxBIF
+class {
+
+	/**
+	 * Generate an image and return the base64 payload.
+	 *
+	 * @prompt The prompt or message to send to the model
+	 * @params Provider-specific parameters (model, temperature, etc.)
+	 * @options Request options (timeout, logging, etc.)
+	 * @outputPath Optional file path to write the decoded image bytes
+	 * @format Optional output format (jpeg, png, svg). Only used when writing to disk.
+	 */
+	function invoke(
+		required any prompt,
+		struct params = {},
+		struct options = {},
+		string outputPath = "",
+		string format = "png"
+	) {
+		// Ensure we request image output
+		var effectiveOptions = arguments.options;
+		effectiveOptions.returnFormat = "image";
+
+		// Request the base64 image
+		var base64 = aiChat( arguments.prompt, arguments.params, effectiveOptions );
+
+		// Optionally write to disk
+		if( arguments.outputPath.len() ){
+			var payload = toString( base64 );
+			// Strip data URI prefix if present
+			if( payload.startsWith( "data:" ) ){
+				var parts = payload.listToArray( "," );
+				if( parts.len() > 1 ){
+					payload = parts[ 1 ];
+				}
+			}
+
+			var bytes = toBinary( payload );
+			fileWriteBinary( arguments.outputPath, bytes );
+		}
+
+		return base64;
+	}
+
+}

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -12,7 +12,7 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  * ----------------------------------------------------------------------------------
- * Create an image using the OpenAI Responses API.
+ * Create an image using the specified provider's API.
  * This is a convenience wrapper around aiChat() with returnFormat="image".
  */
 @BoxBIF

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -25,14 +25,12 @@ class {
 	 * @params Provider-specific parameters (model, temperature, etc.)
 	 * @options Request options (timeout, logging, etc.)
 	 * @outputPath Optional file path to write the decoded image bytes
-	 * @format Optional output format (jpeg, png, svg). Only used when writing to disk.
 	 */
 	function invoke(
 		required any messages,
 		struct params = {},
 		struct options = {},
 		string outputPath = "",
-		string format = "png"
 		
 	) {
 		// Ensure we request image output

--- a/src/main/bx/bifs/aiImage.bx
+++ b/src/main/bx/bifs/aiImage.bx
@@ -45,7 +45,7 @@ class {
 		// Optionally write to disk
 		if( arguments.outputPath.len() ){
 			var bytes = toBinary( toString(base64) );
-			fileWrite( arguments.outputPath, bytes );
+			fileWrite( expandPath( arguments.outputPath ), bytes );
 		}
 
 		return base64;

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -274,26 +274,28 @@ abstract class implements="IAiService" {
 
 		// If an error is returned, throw it
 		if( result.keyExists( "error" ) ){
-			writeLog(
-				text: result.error.toString(),
-				type: "error",
-				log : "ai"
-			)
+			if( !isNull(result.error)){
+				writeLog(
+					text: result.error.toString(),
+					type: "error",
+					log : "ai"
+				)
 
-			// Announce the error
-			BoxAnnounce( "onAIError", {
-				error: result.error,
-				errorMessage: result.error.toString(),
-				provider: this,
-				operation: "chat",
-				aiRequest: arguments.chatRequest,
-				canRetry: true
-			} );
+				// Announce the error
+				BoxAnnounce( "onAIError", {
+					error: result.error,
+					errorMessage: result.error.toString(),
+					provider: this,
+					operation: "chat",
+					aiRequest: arguments.chatRequest,
+					canRetry: true
+				} );
 
-			throw(
-				type   : "ProviderError",
-				message: result.error.toString()
-			);
+				throw(
+					type   : "ProviderError",
+					message: result.error.toString()
+				);
+			}
 		}
 
 		// Announce token usage if available

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -685,31 +685,33 @@ abstract class implements="IAiService" {
 
 		// Build the input array (text + image inputs)
 		var input = [];
+		var message = {type: "message", role: "user", content: []}
 		var textFragments = [];
-		chatRequest.getMessages().each( msg -> {
+		for( var msg in chatRequest.getMessages() ){
 			if( isSimpleValue( msg ) ){
 				textFragments.append( toString( msg ) );
 			} else if( isStruct( msg ) && msg.keyExists( "content" ) ){
 				textFragments.append( toString( msg.content ) );
 			}
-		} );
+		}
 		var joinedText = textFragments.filter( v -> v.len() ).join( "\n" );
 		if( joinedText.len() ){
-			input.append( {
-				"type" : "text",
+			message.content.append( {
+				"type" : "input_text",
 				"text" : joinedText
 			} );
 		}
 
 		// Add any image inputs
 		if( chatRequest.images.len() ){
-			chatRequest.images.each( imageValue -> {
-				input.append( {
+			for( var imageValue in chatRequest.images ){
+				message.content.append( {
 					"type"      : "input_image",
 					"image_url" : toString( imageValue )
 				} );
-			} );
+			}
 		}
+		input.append(message)
 
 		// Build the new packet
 		var newPacket = {

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -46,11 +46,6 @@ abstract class implements="IAiService" {
 	property name = "chatURL" default = "";
 
 	/**
-	 * The responses URL of the provider API (OpenAI Response API)
-	 */
-	property name = "responsesURL" default = "";
-
-	/**
 	 * The embeddings URL of the provider API
 	 */
 	property name = "embeddingsURL" default = "";
@@ -322,8 +317,10 @@ abstract class implements="IAiService" {
 			} );
 		}
 
-		// If we used the Responses API, handle response types accordingly (Responses API does not use choices/tool_calls)
-		if( useResponsesApi ){
+		// For OpenAI, if image input or output is used, the Response API is utilized and is parsed here.
+		if( arguments.chatRequest.getReturnFormat() == "image" ||
+		 arguments.chatRequest.images.len() ||
+		(arguments.dataPacket.keyExists( "tools" ) && isArray( arguments.dataPacket.tools) )){
 			switch( arguments.chatRequest.getReturnFormat() ){
 				case "image":
 					return extractImageFromResponses( result );
@@ -650,22 +647,7 @@ abstract class implements="IAiService" {
 	 * @return The (possibly modified) dataPacket struct
 	 */
 	private struct function preChatRequest( required AiChatRequest chatRequest, required struct dataPacket ){
-		// If we are using the OpenAI Responses API for image generation or image input, reshape the packet accordingly
-		if( shouldUseResponsesApi( arguments.chatRequest, arguments.dataPacket ) ){
-			return buildResponsesApiPacket( arguments.chatRequest, arguments.dataPacket );
-		}
 		return arguments.dataPacket;
-	}
-
-	/**
-	 * Determine if the request should be routed through the OpenAI Responses API.
-	 *
-	 * Returns false by default. Override in OpenAI-compatible providers only.
-	 * Non-OpenAI providers (Claude, Gemini, etc.) must NOT route through the
-	 * Responses API regardless of returnFormat or images options.
-	 */
-	private boolean function shouldUseResponsesApi(){
-		return false;
 	}
 
 	/**
@@ -903,9 +885,6 @@ abstract class implements="IAiService" {
 		}
 
 		var requestUrl = getChatURL();
-		if( shouldUseResponsesApi( arguments.chatRequest, arguments.dataPacket ) ){
-			requestUrl = variables.responsesURL ?: requestUrl;
-		}
 
 		bx: http
 			url     = requestUrl

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -320,7 +320,7 @@ abstract class implements="IAiService" {
 		// For OpenAI, if image input or output is used, the Response API is utilized and is parsed here.
 		if( arguments.chatRequest.getReturnFormat() == "image" ||
 		 arguments.chatRequest.images.len() ||
-		(arguments.dataPacket.keyExists( "tools" ) && isArray( arguments.dataPacket.tools) )){
+		(dataPacket.keyExists( "tools" ) && isArray(dataPacket.tools) )){
 			switch( arguments.chatRequest.getReturnFormat() ){
 				case "image":
 					return extractImageFromResponses( result );

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -179,6 +179,22 @@ abstract class implements="IAiService" {
 	 * @return The response from the provider according to the return format in the AI request
 	 */
 	function invoke( required AiChatRequest chatRequest ){
+		// Guard: image generation is provider-specific — fail fast with a clear message
+		if( arguments.chatRequest.getReturnFormat() == "image" && !supportsImageGeneration() ){
+			throw(
+				type   : "UnsupportedFeature",
+				message: "The '#variables.name#' provider does not support image generation (returnFormat=""image""). Use the OpenAI provider instead."
+			);
+		}
+
+		// Guard: image input is provider-specific — fail fast with a clear message
+		if( arguments.chatRequest.images.len() && !supportsImageInput() ){
+			throw(
+				type   : "UnsupportedFeature",
+				message: "The '#variables.name#' provider does not support image input (options.images). Use the OpenAI provider instead."
+			);
+		}
+
 		// Model Selection if not set, use the default in the service, which should always be set
 		chatRequest
 			.setModelIfEmpty( variables.params.model ?: "" )
@@ -651,24 +667,27 @@ abstract class implements="IAiService" {
 	/**
 	 * Determine if the request should be routed through the OpenAI Responses API.
 	 *
-	 * This is true for:
-	 * - returnFormat == "image" (image generation)
-	 * - explicit tools with type "image_generation"
-	 * - image inputs provided via chatRequest.images
+	 * Returns false by default. Override in OpenAI-compatible providers only.
+	 * Non-OpenAI providers (Claude, Gemini, etc.) must NOT route through the
+	 * Responses API regardless of returnFormat or images options.
 	 */
-	private boolean function shouldUseResponsesApi( required AiChatRequest chatRequest, required struct dataPacket ){
-		if( chatRequest.getReturnFormat() == "image" ){
-			return true;
-		}
+	private boolean function shouldUseResponsesApi(){
+		return false;
+	}
 
-		if( chatRequest.images.len() ){
-			return true;
-		}
+	/**
+	 * Whether this provider supports image generation (returnFormat="image").
+	 * Returns false by default. Override to return true in providers that support it.
+	 */
+	private boolean function supportsImageGeneration(){
+		return false;
+	}
 
-		if( dataPacket.keyExists( "tools" ) && isArray( dataPacket.tools ) ){
-			return dataPacket.tools.any( tool -> isStruct( tool ) && tool.keyExists( "type" ) && toString( tool.type ) == "image_generation" );
-		}
-
+	/**
+	 * Whether this provider supports image input (options.images).
+	 * Returns false by default. Override to return true in providers that support it.
+	 */
+	private boolean function supportsImageInput(){
 		return false;
 	}
 

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -747,21 +747,17 @@ abstract class implements="IAiService" {
 	 */
 	private string function extractImageFromResponses( required struct result ){
 		var outputItems = result.output ?: [];
-		if( !isArray( outputItems ) ){
-			return "";
+		for( var item in outputItems ){
+			if( !isStruct( item ) ){
+				continue;
+			}
+			if(item.keyExists("type")) {
+				if(item.type == "image_generation_call") {
+					return item.result
+				}
+			}
 		}
-
-		var imageItem = outputItems.find( item -> isStruct( item ) && item.keyExists( "type" ) && toString( item.type ) == "ImageGenerationCall" );
-		if( imageItem == null ){
-			imageItem = outputItems.find( item -> isStruct( item ) && item.keyExists( "type" ) && toString( item.type ) == "image_generation" );
-		}
-
-		if( imageItem == null ){
-			return "";
-		}
-
-		// Common field names for base64 payloads
-		return imageItem.image_b64 ?: imageItem.image_base64 ?: imageItem.base64 ?: "";
+		return ""
 	}
 
 	/**
@@ -769,31 +765,19 @@ abstract class implements="IAiService" {
 	 */
 	private string function extractTextFromResponses( required struct result ){
 		var outputItems = result.output ?: [];
-		if( !isArray( outputItems ) ){
-			return "";
-		}
-
+		var finalText = ""
 		for( var item in outputItems ){
 			if( !isStruct( item ) ){
 				continue;
 			}
-
-			// Common text output forms
-			if( item.keyExists( "text" ) && isSimpleValue( item.text ) ){
-				return toString( item.text );
-			}
-			if( item.keyExists( "content" ) && isSimpleValue( item.content ) ){
-				return toString( item.content );
-			}
-			if( item.keyExists( "output" ) && isArray( item.output ) ){
-				var nested = item.output.first();
-				if( isStruct( nested ) && nested.keyExists( "text" ) ){
-					return toString( nested.text );
+			if(item.keyExists("type")) {
+				if(item.type == "message") {
+					for(var messageObject in item.content)
+					finalText &= messageObject.text
 				}
 			}
 		}
-
-		return "";
+		return finalText;
 	}
 
 	/**

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -320,7 +320,7 @@ abstract class implements="IAiService" {
 		// For OpenAI, if image input or output is used, the Response API is utilized and is parsed here.
 		if( arguments.chatRequest.getReturnFormat() == "image" ||
 		 arguments.chatRequest.images.len() ||
-		(dataPacket.keyExists( "tools" ) && isArray(dataPacket.tools) )){
+		imageToolExists(dataPacket)) {
 			switch( arguments.chatRequest.getReturnFormat() ){
 				case "image":
 					return extractImageFromResponses( result );
@@ -333,7 +333,7 @@ abstract class implements="IAiService" {
 					return extractedText.len() ? extractedText : result;
 			}
 		}
-
+		
 		// Result returns, only if we are not using tool calls
 		var toolCalls = result.choices.first().message?.tool_calls ?: arrayNew()
 		if( !toolCalls.len() ){
@@ -666,74 +666,19 @@ abstract class implements="IAiService" {
 		return false;
 	}
 
-	/**
-	 * Build a Responses API payload from a standard Chat Completions-style packet.
-	 */
-	private struct function buildResponsesApiPacket( required AiChatRequest chatRequest, required struct dataPacket ){
-		// Ensure image generation tool is present when returnFormat is image
-		var tools = ( dataPacket.keyExists( "tools" ) && isArray( dataPacket.tools ) ) ? dataPacket.tools : [];
-		if( chatRequest.getReturnFormat() == "image" ){
-			var hasImageTool = false;
-			for(var tool in tools) {
-				if(isStruct(tool) && tool.keyExists("type") && toString(tool.type) == "image_generation") {
-					hasImageTool = true;
-					break;
+	private boolean function imageToolExists(struct dataPacket) {
+		if(dataPacket.keyExists( "tools" ) ) {
+			if(isStruct(dataPacket.tools)) {
+				for(tool in dataPacket.tools) {
+					if(tool.keyExists("type")) {
+						if (toString(tool.type) == "image_generation") {
+							return true;
+						}
+					}
 				}
 			}
-			if(!hasImageTool) {
-				tools.append( { "type": "image_generation" } );
-			}
 		}
-
-		// Build the input array (text + image inputs)
-		var input = [];
-		var message = {type: "message", role: "user", content: []}
-		var textFragments = [];
-		for( var msg in chatRequest.getMessages() ){
-			if( isSimpleValue( msg ) ){
-				textFragments.append( toString( msg ) );
-			} else if( isStruct( msg ) && msg.keyExists( "content" ) ){
-				textFragments.append( toString( msg.content ) );
-			}
-		}
-		var joinedText = textFragments.filter( v -> v.len() ).join( "\n" );
-		if( joinedText.len() ){
-			message.content.append( {
-				"type" : "input_text",
-				"text" : joinedText
-			} );
-		}
-
-		// Add any image inputs
-		if( chatRequest.images.len() ){
-			for( var imageValue in chatRequest.images ){
-				message.content.append( {
-					"type"      : "input_image",
-					"image_url" : toString( imageValue )
-				} );
-			}
-		}
-		input.append(message)
-
-		// Build the new packet
-		var newPacket = {
-			"model" : dataPacket.model,
-			"input" : input
-		};
-
-		// Preserve other params (excluding messages)
-		for( var key in dataPacket ){ 
-			if( key != "model" && key != "messages" && key != "input" ){
-				newPacket[ key ] = dataPacket[ key ];
-			}
-		}
-
-		// Ensure tools is updated
-		if( tools.len() ){
-			newPacket.tools = tools;
-		}
-
-		return newPacket;
+		return false;
 	}
 
 	/**

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -679,8 +679,14 @@ abstract class implements="IAiService" {
 		// Ensure image generation tool is present when returnFormat is image
 		var tools = ( dataPacket.keyExists( "tools" ) && isArray( dataPacket.tools ) ) ? dataPacket.tools : [];
 		if( chatRequest.getReturnFormat() == "image" ){
-			var hasImageTool = tools.any( tool -> isStruct( tool ) && tool.keyExists( "type" ) && toString( tool.type ) == "image_generation" );
-			if( !hasImageTool ){
+			var hasImageTool = false;
+			for(var tool in tools) {
+				if(isStruct(tool) && tool.keyExists("type") && toString(tool.type) == "image_generation") {
+					hasImageTool = true;
+					break;
+				}
+			}
+			if(!hasImageTool) {
 				tools.append( { "type": "image_generation" } );
 			}
 		}

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -257,13 +257,6 @@ abstract class implements="IAiService" {
 			dataPacket.tools = dataPacket.tools.map( .getSchema )
 		}
 
-		// If we are using the OpenAI Responses API (for image generation / image input), transform the packet
-		// to the newer Responses API format (input array, tool-based image generation, etc.)
-		var useResponsesApi = shouldUseResponsesApi( arguments.chatRequest, dataPacket );
-		if( useResponsesApi ){
-			dataPacket = buildResponsesApiPacket( arguments.chatRequest, dataPacket );
-		}
-
 		// Structured output support (OpenAI format)
 		if( arguments.chatRequest.isStructuredOutput() ){
 			// Clean internal metadata before sending to provider

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -46,6 +46,11 @@ abstract class implements="IAiService" {
 	property name = "chatURL" default = "";
 
 	/**
+	 * The responses URL of the provider API (OpenAI Response API)
+	 */
+	property name = "responsesURL" default = "";
+
+	/**
 	 * The embeddings URL of the provider API
 	 */
 	property name = "embeddingsURL" default = "";
@@ -236,6 +241,13 @@ abstract class implements="IAiService" {
 			dataPacket.tools = dataPacket.tools.map( .getSchema )
 		}
 
+		// If we are using the OpenAI Responses API (for image generation / image input), transform the packet
+		// to the newer Responses API format (input array, tool-based image generation, etc.)
+		var useResponsesApi = shouldUseResponsesApi( arguments.chatRequest, dataPacket );
+		if( useResponsesApi ){
+			dataPacket = buildResponsesApiPacket( arguments.chatRequest, dataPacket );
+		}
+
 		// Structured output support (OpenAI format)
 		if( arguments.chatRequest.isStructuredOutput() ){
 			// Clean internal metadata before sending to provider
@@ -297,6 +309,21 @@ abstract class implements="IAiService" {
 				usage: result.usage,
 				timestamp: now()
 			} );
+		}
+
+		// If we used the Responses API, handle response types accordingly (Responses API does not use choices/tool_calls)
+		if( useResponsesApi ){
+			switch( arguments.chatRequest.getReturnFormat() ){
+				case "image":
+					return extractImageFromResponses( result );
+				case "raw":
+					return result;
+				case "all":
+					return result.output ?: result;
+				case "single": default:
+					var extractedText = extractTextFromResponses( result );
+					return extractedText.len() ? extractedText : result;
+			}
 		}
 
 		// Result returns, only if we are not using tool calls
@@ -612,7 +639,151 @@ abstract class implements="IAiService" {
 	 * @return The (possibly modified) dataPacket struct
 	 */
 	private struct function preChatRequest( required AiChatRequest chatRequest, required struct dataPacket ){
+		// If we are using the OpenAI Responses API for image generation or image input, reshape the packet accordingly
+		if( shouldUseResponsesApi( arguments.chatRequest, arguments.dataPacket ) ){
+			return buildResponsesApiPacket( arguments.chatRequest, arguments.dataPacket );
+		}
 		return arguments.dataPacket;
+	}
+
+	/**
+	 * Determine if the request should be routed through the OpenAI Responses API.
+	 *
+	 * This is true for:
+	 * - returnFormat == "image" (image generation)
+	 * - explicit tools with type "image_generation"
+	 * - image inputs provided via chatRequest.images
+	 */
+	private boolean function shouldUseResponsesApi( required AiChatRequest chatRequest, required struct dataPacket ){
+		if( chatRequest.getReturnFormat() == "image" ){
+			return true;
+		}
+
+		if( chatRequest.images.len() ){
+			return true;
+		}
+
+		if( dataPacket.keyExists( "tools" ) && isArray( dataPacket.tools ) ){
+			return dataPacket.tools.any( tool -> isStruct( tool ) && tool.keyExists( "type" ) && toString( tool.type ) == "image_generation" );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Build a Responses API payload from a standard Chat Completions-style packet.
+	 */
+	private struct function buildResponsesApiPacket( required AiChatRequest chatRequest, required struct dataPacket ){
+		// Ensure image generation tool is present when returnFormat is image
+		var tools = ( dataPacket.keyExists( "tools" ) && isArray( dataPacket.tools ) ) ? dataPacket.tools : [];
+		if( chatRequest.getReturnFormat() == "image" ){
+			var hasImageTool = tools.any( tool -> isStruct( tool ) && tool.keyExists( "type" ) && toString( tool.type ) == "image_generation" );
+			if( !hasImageTool ){
+				tools.append( { "type": "image_generation" } );
+			}
+		}
+
+		// Build the input array (text + image inputs)
+		var input = [];
+		var textFragments = [];
+		chatRequest.getMessages().each( msg -> {
+			if( isSimpleValue( msg ) ){
+				textFragments.append( toString( msg ) );
+			} else if( isStruct( msg ) && msg.keyExists( "content" ) ){
+				textFragments.append( toString( msg.content ) );
+			}
+		} );
+		var joinedText = textFragments.filter( v -> v.len() ).join( "\n" );
+		if( joinedText.len() ){
+			input.append( {
+				"type" : "text",
+				"text" : joinedText
+			} );
+		}
+
+		// Add any image inputs
+		if( chatRequest.images.len() ){
+			chatRequest.images.each( imageValue -> {
+				input.append( {
+					"type"      : "input_image",
+					"image_url" : toString( imageValue )
+				} );
+			} );
+		}
+
+		// Build the new packet
+		var newPacket = {
+			"model" : dataPacket.model,
+			"input" : input
+		};
+
+		// Preserve other params (excluding messages)
+		for( var key in dataPacket ){ 
+			if( key != "model" && key != "messages" && key != "input" ){
+				newPacket[ key ] = dataPacket[ key ];
+			}
+		}
+
+		// Ensure tools is updated
+		if( tools.len() ){
+			newPacket.tools = tools;
+		}
+
+		return newPacket;
+	}
+
+	/**
+	 * Extract an image base64 string from a Responses API response.
+	 */
+	private string function extractImageFromResponses( required struct result ){
+		var outputItems = result.output ?: [];
+		if( !isArray( outputItems ) ){
+			return "";
+		}
+
+		var imageItem = outputItems.find( item -> isStruct( item ) && item.keyExists( "type" ) && toString( item.type ) == "ImageGenerationCall" );
+		if( imageItem == null ){
+			imageItem = outputItems.find( item -> isStruct( item ) && item.keyExists( "type" ) && toString( item.type ) == "image_generation" );
+		}
+
+		if( imageItem == null ){
+			return "";
+		}
+
+		// Common field names for base64 payloads
+		return imageItem.image_b64 ?: imageItem.image_base64 ?: imageItem.base64 ?: "";
+	}
+
+	/**
+	 * Extract the first available text output from a Responses API response.
+	 */
+	private string function extractTextFromResponses( required struct result ){
+		var outputItems = result.output ?: [];
+		if( !isArray( outputItems ) ){
+			return "";
+		}
+
+		for( var item in outputItems ){
+			if( !isStruct( item ) ){
+				continue;
+			}
+
+			// Common text output forms
+			if( item.keyExists( "text" ) && isSimpleValue( item.text ) ){
+				return toString( item.text );
+			}
+			if( item.keyExists( "content" ) && isSimpleValue( item.content ) ){
+				return toString( item.content );
+			}
+			if( item.keyExists( "output" ) && isArray( item.output ) ){
+				var nested = item.output.first();
+				if( isStruct( nested ) && nested.keyExists( "text" ) ){
+					return toString( nested.text );
+				}
+			}
+		}
+
+		return "";
 	}
 
 	/**
@@ -725,8 +896,13 @@ abstract class implements="IAiService" {
 			println( buildRequestLog( arguments.chatRequest, arguments.dataPacket ) )
 		}
 
+		var requestUrl = getChatURL();
+		if( shouldUseResponsesApi( arguments.chatRequest, arguments.dataPacket ) ){
+			requestUrl = variables.responsesURL ?: requestUrl;
+		}
+
 		bx: http
-			url     = getChatURL()
+			url     = requestUrl
 			method  = "post"
 			result  = "chatResult"
 			charset = "utf-8"

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -152,4 +152,67 @@ class extends="BaseService"{
 		variables.chatURL = originalChatUrl;
 		return response;
 	}
+
+	/**
+	 * Build a Responses API payload from a standard Chat Completions-style packet.
+	 */
+	private struct function buildResponsesApiPacket( required AiChatRequest chatRequest, required struct dataPacket ){
+		// Ensure image generation tool is present when returnFormat is image
+		var tools = (dataPacket.keyExists( "tools" )) ? dataPacket.tools : [];
+		if( chatRequest.getReturnFormat() == "image" && isArray( tools ) ){
+			if(!imageToolExists(dataPacket)) {
+				tools.append( { "type": "image_generation" } );
+			}
+		}
+
+		// Build the input array (text + image inputs)
+		var input = [];
+		var message = {type: "message", role: "user", content: []}
+		var textFragments = [];
+		for( var msg in chatRequest.getMessages() ){
+			if( isSimpleValue( msg ) ){
+				textFragments.append( toString( msg ) );
+			} else if( isStruct( msg ) && msg.keyExists( "content" ) ){
+				textFragments.append( toString( msg.content ) );
+			}
+		}
+		var joinedText = textFragments.filter( v -> v.len() ).join( "\n" );
+		if( joinedText.len() ){
+			message.content.append( {
+				"type" : "input_text",
+				"text" : joinedText
+			} );
+		}
+
+		// Add any image inputs
+		if( chatRequest.images.len() ){
+			for( var imageValue in chatRequest.images ){
+				message.content.append( {
+					"type"      : "input_image",
+					"image_url" : toString( imageValue )
+				} );
+			}
+		}
+		input.append(message)
+
+		// Build the new packet
+		var newPacket = {
+			"model" : dataPacket.model,
+			"input" : input
+		};
+
+		// Preserve other params (excluding messages)
+		for( var key in dataPacket ){ 
+			if( key != "model" && key != "messages" && key != "input" ){
+				newPacket[ key ] = dataPacket[ key ];
+			}
+		}
+
+		// Ensure tools is updated
+		if( tools.len() ){
+			newPacket.tools = tools;
+		}
+
+		return newPacket;
+	}
 }

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -111,7 +111,13 @@ class extends="BaseService"{
 		}
 
 		if( arguments.dataPacket.keyExists( "tools" ) && isArray( arguments.dataPacket.tools ) ){
-			return arguments.dataPacket.tools.any( tool -> isStruct( tool ) && tool.keyExists( "type" ) && toString( tool.type ) == "image_generation" );
+			for(tool in arguments.dataPacket.tools) {
+				if(tool.keyExists("type")) {
+					if (toString(tool.type) == "image_generation") {
+						return true;
+					}
+				}
+			}
 		}
 
 		return false;

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -14,6 +14,11 @@
  * ----------------------------------------------------------------------------------
  */
 class extends="BaseService"{
+/**
+	 * The responses URL of the provider API (OpenAI Response API)
+	 */
+	property name = "responsesURL" default = "";
+
 
 	/**
 	 * Static defaults
@@ -67,24 +72,36 @@ class extends="BaseService"{
 		return super.invokeStream( arguments.chatRequest, arguments.callback )
 	}
 
+	/**
+	 * Override to set default embedding model if not specified
+	 */
+	@override
+	public function embeddings( required AiEmbeddingRequest embeddingRequest ){
+		// Set default embedding model if not specified
+		arguments.embeddingRequest.mergeServiceParams( static.DEFAULT_EMBED_PARAMS )
+		return super.embeddings( embeddingRequest )
+	}
+
+	/**
+	 * Override since OpenAI does support image generation
+	 */
 	@override
 	private boolean function supportsImageGeneration(){
 		return true;
 	}
 
+	/**
+	 * Override since OpenAI does support image input
+	 */
 	@override
 	private boolean function supportsImageInput(){
 		return true;
 	}
 
-	/**
-	 * OpenAI uses the Responses API for image generation, image input, and image_generation tools.
-	 * This override enables that routing exclusively for OpenAI-compatible providers.
-	 *
-	 * @chatRequest The AI request being processed
-	 * @dataPacket  The assembled data packet
+	/*	 *
+	 * OpenAI uses the Responses API for image generation, image input, and image_generation tools
+	 * This enables that routing
 	 */
-	@override
 	private boolean function shouldUseResponsesApi( required AiChatRequest chatRequest, required struct dataPacket ){
 		if( arguments.chatRequest.getReturnFormat() == "image" ){
 			return true;
@@ -101,14 +118,145 @@ class extends="BaseService"{
 		return false;
 	}
 
-	/**
-	 * Override to set default embedding model if not specified
+/**
+	 * Override to check if Response API should be utilized
 	 */
 	@override
-	public function embeddings( required AiEmbeddingRequest embeddingRequest ){
-		// Set default embedding model if not specified
-		arguments.embeddingRequest.mergeServiceParams( static.DEFAULT_EMBED_PARAMS )
-		return super.embeddings( embeddingRequest )
+	private struct function preChatRequest( required AiChatRequest chatRequest, required struct dataPacket ){
+		// If we are using the OpenAI Responses API for image generation or image input, reshape the packet accordingly
+		if( shouldUseResponsesApi( arguments.chatRequest, arguments.dataPacket ) ){
+			return buildResponsesApiPacket( arguments.chatRequest, arguments.dataPacket );
+		}
+		return arguments.dataPacket;
 	}
 
+	/**
+	 * Overrides chatURL routing when using Response API
+	 	 */
+	@override 
+	private function sendChatRequest( required AiChatRequest chatRequest, required struct dataPacket ){
+		if(!shouldUseResponsesApi(arguments.chatRequest, arguments.dataPacket)){
+			super.sendChatRequest(arguments.chatRequest, arguments.dataPacket)
+		}
+		else {
+			// Announce the request
+			BoxAnnounce(
+				"onAIChatRequest",
+				{
+					"dataPacket" : arguments.dataPacket,
+					"chatRequest": arguments.chatRequest,
+					"provider"   : this
+				}
+			);
+
+			// Log the request to the logs if enabled
+			if( arguments.chatRequest.getLogRequest() ){
+				writeLog(
+					text: buildRequestLog( arguments.chatRequest, arguments.dataPacket ),
+					type: "info",
+					log : "ai"
+				)
+			}
+
+			// Log the request to the console if enabled
+			if( arguments.chatRequest.getLogRequestToConsole() ){
+				println( buildRequestLog( arguments.chatRequest, arguments.dataPacket ) )
+			}
+
+			var requestUrl = variables.responsesURL ?: requestUrl;
+
+			bx: http
+				url     = requestUrl
+				method  = "post"
+				result  = "chatResult"
+				charset = "utf-8"
+				timeout = arguments.chatRequest.getTimeout()
+			{
+				bx:httpParam type="header" name="content-type" value="application/json";
+
+				// Auth Header ONLY if the provider requires it
+				// This is the default for OpenAI
+				// If the provider does not require it, set it to false
+				if( arguments.chatRequest.getSendAuthHeader() ){
+					bx:httpParam type="header" name="Authorization" value="Bearer #arguments.chatRequest.getApiKey()#";
+				}
+
+				// Custom Headers
+				for( var thisHeader in arguments.chatRequest.getHeaders() ){
+					bx:httpParam
+						type="header"
+						name="#thisHeader#"
+						value="#arguments.chatRequest.getHeaders()[ thisHeader ]#";
+				}
+
+				// Body Packet
+				bx:httpParam type="body" value=jsonSerialize( arguments.dataPacket );
+			}
+
+			// Check for rate limiting (429 status code)
+			if( chatResult.statusCode == "429" || chatResult.statusCode == 429 ){
+				var errorData = {};
+				try {
+					errorData = jsonDeserialize( chatResult.filecontent );
+				} catch( any e ){
+					errorData = { message: chatResult.filecontent };
+				}
+
+				// Announce rate limit hit
+				BoxAnnounce( "onAIRateLimitHit", {
+					provider: this,
+					operation: "chat",
+					statusCode: chatResult.statusCode,
+					errorData: errorData,
+					chatRequest: arguments.chatRequest,
+					retryAfter: chatResult.responseheader.keyExists( "retry-after" ) ? chatResult.responseheader[ "retry-after" ] : ""
+				} );
+			}
+
+			// Final logging if the provider supports it
+			if( arguments.chatRequest.getLogResponse() ){
+				writeLog(
+					text: buildResponseLog( arguments.chatRequest, chatResult ),
+					type: "info",
+					log : "ai"
+				)
+			}
+
+			// Log the response to the console if enabled
+			if( arguments.chatRequest.getLogResponseToConsole() ){
+				println( buildResponseLog( arguments.chatRequest, chatResult ) )
+			}
+
+			// Try to deserialize the response
+			try{
+				var iData = {
+					"chatRequest" 	: arguments.chatRequest,
+					"response" 		: jsonDeserialize( chatResult.filecontent ),
+					"rawResponse"	: chatResult,
+					"provider" 		: this
+				}
+			}
+			catch( Any e ){
+				// Announce the error
+				BoxAnnounce( "onAIError", {
+					error: e,
+					errorMessage: "Error deserializing response: #chatResult.filecontent#",
+					provider: this,
+					operation: "sendChatRequest",
+					aiRequest: arguments.chatRequest,
+					canRetry: true
+				} );
+
+				throw(
+					type   : "JsonDeserializationError",
+					message: "Error deserializing response from provider: #e.message & e.detail#",
+					detail: "Response: #chatResult.filecontent#"
+				);
+			}
+
+			BoxAnnounce( "onAIChatResponse", iData );
+
+			return iData.response;
+		}
+	}
 }

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -14,11 +14,10 @@
  * ----------------------------------------------------------------------------------
  */
 class extends="BaseService"{
-/**
+	/**
 	 * The responses URL of the provider API (OpenAI Response API)
 	 */
 	property name = "responsesURL" default = "";
-
 
 	/**
 	 * Static defaults
@@ -98,7 +97,7 @@ class extends="BaseService"{
 		return true;
 	}
 
-	/*	 *
+	/**
 	 * OpenAI uses the Responses API for image generation, image input, and image_generation tools
 	 * This enables that routing
 	 */
@@ -118,7 +117,7 @@ class extends="BaseService"{
 		return false;
 	}
 
-/**
+	/**
 	 * Override to check if Response API should be utilized
 	 */
 	@override
@@ -132,131 +131,19 @@ class extends="BaseService"{
 
 	/**
 	 * Overrides chatURL routing when using Response API
-	 	 */
+	 */
 	@override 
 	private function sendChatRequest( required AiChatRequest chatRequest, required struct dataPacket ){
-		if(!shouldUseResponsesApi(arguments.chatRequest, arguments.dataPacket)){
-			super.sendChatRequest(arguments.chatRequest, arguments.dataPacket)
+		originalChatUrl = variables.chatURL;
+
+		if(shouldUseResponsesApi(arguments.chatRequest, arguments.dataPacket)){
+			//Injects responseURL into sendChatRequest when it calls getChatURL()
+			variables.chatURL = variables.responsesURL;
 		}
-		else {
-			// Announce the request
-			BoxAnnounce(
-				"onAIChatRequest",
-				{
-					"dataPacket" : arguments.dataPacket,
-					"chatRequest": arguments.chatRequest,
-					"provider"   : this
-				}
-			);
+		response = super.sendChatRequest(arguments.chatRequest, arguments.dataPacket);
 
-			// Log the request to the logs if enabled
-			if( arguments.chatRequest.getLogRequest() ){
-				writeLog(
-					text: buildRequestLog( arguments.chatRequest, arguments.dataPacket ),
-					type: "info",
-					log : "ai"
-				)
-			}
-
-			// Log the request to the console if enabled
-			if( arguments.chatRequest.getLogRequestToConsole() ){
-				println( buildRequestLog( arguments.chatRequest, arguments.dataPacket ) )
-			}
-
-			var requestUrl = variables.responsesURL ?: requestUrl;
-
-			bx: http
-				url     = requestUrl
-				method  = "post"
-				result  = "chatResult"
-				charset = "utf-8"
-				timeout = arguments.chatRequest.getTimeout()
-			{
-				bx:httpParam type="header" name="content-type" value="application/json";
-
-				// Auth Header ONLY if the provider requires it
-				// This is the default for OpenAI
-				// If the provider does not require it, set it to false
-				if( arguments.chatRequest.getSendAuthHeader() ){
-					bx:httpParam type="header" name="Authorization" value="Bearer #arguments.chatRequest.getApiKey()#";
-				}
-
-				// Custom Headers
-				for( var thisHeader in arguments.chatRequest.getHeaders() ){
-					bx:httpParam
-						type="header"
-						name="#thisHeader#"
-						value="#arguments.chatRequest.getHeaders()[ thisHeader ]#";
-				}
-
-				// Body Packet
-				bx:httpParam type="body" value=jsonSerialize( arguments.dataPacket );
-			}
-
-			// Check for rate limiting (429 status code)
-			if( chatResult.statusCode == "429" || chatResult.statusCode == 429 ){
-				var errorData = {};
-				try {
-					errorData = jsonDeserialize( chatResult.filecontent );
-				} catch( any e ){
-					errorData = { message: chatResult.filecontent };
-				}
-
-				// Announce rate limit hit
-				BoxAnnounce( "onAIRateLimitHit", {
-					provider: this,
-					operation: "chat",
-					statusCode: chatResult.statusCode,
-					errorData: errorData,
-					chatRequest: arguments.chatRequest,
-					retryAfter: chatResult.responseheader.keyExists( "retry-after" ) ? chatResult.responseheader[ "retry-after" ] : ""
-				} );
-			}
-
-			// Final logging if the provider supports it
-			if( arguments.chatRequest.getLogResponse() ){
-				writeLog(
-					text: buildResponseLog( arguments.chatRequest, chatResult ),
-					type: "info",
-					log : "ai"
-				)
-			}
-
-			// Log the response to the console if enabled
-			if( arguments.chatRequest.getLogResponseToConsole() ){
-				println( buildResponseLog( arguments.chatRequest, chatResult ) )
-			}
-
-			// Try to deserialize the response
-			try{
-				var iData = {
-					"chatRequest" 	: arguments.chatRequest,
-					"response" 		: jsonDeserialize( chatResult.filecontent ),
-					"rawResponse"	: chatResult,
-					"provider" 		: this
-				}
-			}
-			catch( Any e ){
-				// Announce the error
-				BoxAnnounce( "onAIError", {
-					error: e,
-					errorMessage: "Error deserializing response: #chatResult.filecontent#",
-					provider: this,
-					operation: "sendChatRequest",
-					aiRequest: arguments.chatRequest,
-					canRetry: true
-				} );
-
-				throw(
-					type   : "JsonDeserializationError",
-					message: "Error deserializing response from provider: #e.message & e.detail#",
-					detail: "Response: #chatResult.filecontent#"
-				);
-			}
-
-			BoxAnnounce( "onAIChatResponse", iData );
-
-			return iData.response;
-		}
+		//Sets back original chatURL after injection
+		variables.chatURL = originalChatUrl;
+		return response;
 	}
 }

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -67,6 +67,40 @@ class extends="BaseService"{
 		return super.invokeStream( arguments.chatRequest, arguments.callback )
 	}
 
+	@override
+	private boolean function supportsImageGeneration(){
+		return true;
+	}
+
+	@override
+	private boolean function supportsImageInput(){
+		return true;
+	}
+
+	/**
+	 * OpenAI uses the Responses API for image generation, image input, and image_generation tools.
+	 * This override enables that routing exclusively for OpenAI-compatible providers.
+	 *
+	 * @chatRequest The AI request being processed
+	 * @dataPacket  The assembled data packet
+	 */
+	@override
+	private boolean function shouldUseResponsesApi( required AiChatRequest chatRequest, required struct dataPacket ){
+		if( arguments.chatRequest.getReturnFormat() == "image" ){
+			return true;
+		}
+
+		if( arguments.chatRequest.images.len() ){
+			return true;
+		}
+
+		if( arguments.dataPacket.keyExists( "tools" ) && isArray( arguments.dataPacket.tools ) ){
+			return arguments.dataPacket.tools.any( tool -> isStruct( tool ) && tool.keyExists( "type" ) && toString( tool.type ) == "image_generation" );
+		}
+
+		return false;
+	}
+
 	/**
 	 * Override to set default embedding model if not specified
 	 */

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -35,6 +35,7 @@ class extends="BaseService"{
 	 */
 	function init(){
 		variables.chatURL = "https://api.openai.com/v1/chat/completions"
+		variables.responsesURL = "https://api.openai.com/v1/responses"
 		variables.embeddingsURL = "https://api.openai.com/v1/embeddings"
 		variables.name = "OpenAI"
 	}

--- a/src/main/bx/models/requests/AiChatRequest.bx
+++ b/src/main/bx/models/requests/AiChatRequest.bx
@@ -44,6 +44,11 @@ class extends="AiBaseRequest"{
 	property name="structuredOutputDefinition" type="any" default={};
 
 	/**
+	 * Optional images to send as input (base64 strings or data URIs)
+	 */
+	property name="images" type="array" default=[];
+
+	/**
 	 * Constructor
 	 *
 	 * @aiMessage The messages to use for the chat request, or empty for none
@@ -72,6 +77,17 @@ class extends="AiBaseRequest"{
 		variables.timeout = options.timeout ?: 30;
 		variables.stream = options.stream ?: false;
 		variables.maxInteractions = options.maxInteractions ?: 0;
+
+		// Optional image input support (base64 strings or data URIs)
+		var images = [];
+		if( options.keyExists( "images" ) ){
+			if( isArray( options.images ) ){
+				images = options.images;
+			} else if( isSimpleValue( options.images ) ){
+				images = [ arguments.options.images ];
+			}
+		}
+		variables.images = images;
 
 		// Multi-tenant usage tracking options
 		variables.tenantId = options.tenantId ?: "";

--- a/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
@@ -239,4 +239,49 @@ public class OpenAITest extends BaseIntegrationTest {
 		assertThat( variables.get( "runtimeResult" ) ).isInstanceOf( String.class );
 	}
 
+	@DisplayName( "Test image generation return format" )
+	@Test
+	public void testImageReturnFormat() {
+		// This test requires a valid OpenAI API key and will invoke the Responses API.
+		// It should return a base64-encoded image string.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+			imageBase64 = aiChat( "An icon of a red apple on a white background", {}, { returnFormat: "image" } )
+			println( "Image base64 length: " & imageBase64.len() )
+			""",
+			context
+		);
+		// @formatter:on
+
+		var imageBase64 = variables.get( "imageBase64" );
+		assertThat( imageBase64 ).isNotNull();
+		assertThat( imageBase64.toString().len() ).isGreaterThan( 0 );
+	}
+
+	@DisplayName( "Test aiImage helper and image input" )
+	@Test
+	public void testAiImageHelperAndInput() {
+		// Use aiImage() helper
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+			imageBase64 = aiImage( "A single blue circle on a white background" )
+			println( "Generated image base64 length: " & imageBase64.len() )
+
+			// Use an existing base64 image as input to the model
+			// This is a 1x1 PNG white pixel
+			base64Input = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+			desc = aiChat( "Describe the given image", {}, { images: [ base64Input ] } )
+			println( "Image description: " & desc )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( "imageBase64" ) ).isNotNull();
+		assertThat( variables.get( "imageBase64" ).toString().len() ).isGreaterThan( 0 );
+		assertThat( variables.get( "desc" ) ).isNotNull();
+	}
+
 }

--- a/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
@@ -271,7 +271,7 @@ public class OpenAITest extends BaseIntegrationTest {
 
 			// Use an existing base64 image as input to the model
 			// This is a 1x1 PNG white pixel
-			base64Input = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+			base64Input = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAANSURBVBhXY/j///9/AAn7A/0FQ0XKAAAAAElFTkSuQmCC"
 			desc = aiChat( "Describe the given image", {}, { images: [ base64Input ] } )
 			println( "Image description: " & desc )
 			""",

--- a/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
@@ -256,7 +256,7 @@ public class OpenAITest extends BaseIntegrationTest {
 
 		var imageBase64 = variables.get( "imageBase64" );
 		assertThat( imageBase64 ).isNotNull();
-		assertThat( imageBase64.toString().len() ).isGreaterThan( 0 );
+		assertThat( imageBase64.toString().length() ).isGreaterThan( 0 );
 	}
 
 	@DisplayName( "Test aiImage helper and image input" )
@@ -280,7 +280,7 @@ public class OpenAITest extends BaseIntegrationTest {
 		// @formatter:on
 
 		assertThat( variables.get( "imageBase64" ) ).isNotNull();
-		assertThat( variables.get( "imageBase64" ).toString().len() ).isGreaterThan( 0 );
+		assertThat( variables.get( "imageBase64" ).toString().length() ).isGreaterThan( 0 );
 		assertThat( variables.get( "desc" ) ).isNotNull();
 	}
 

--- a/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/OpenAITest.java
@@ -247,7 +247,7 @@ public class OpenAITest extends BaseIntegrationTest {
 		// @formatter:off
 		executeWithTimeoutHandling(
 			"""
-			imageBase64 = aiChat( "An icon of a red apple on a white background", {}, { returnFormat: "image" } )
+			imageBase64 = aiChat( "An icon of a red apple on a white background", {}, { returnFormat: "image", timeout:300 } )
 			println( "Image base64 length: " & imageBase64.len() )
 			""",
 			context
@@ -266,13 +266,13 @@ public class OpenAITest extends BaseIntegrationTest {
 		// @formatter:off
 		executeWithTimeoutHandling(
 			"""
-			imageBase64 = aiImage( "A single blue circle on a white background" )
+			imageBase64 = aiImage( "A single blue circle on a white background", {}, {timeout:300} )
 			println( "Generated image base64 length: " & imageBase64.len() )
 
 			// Use an existing base64 image as input to the model
 			// This is a 1x1 PNG white pixel
 			base64Input = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAANSURBVBhXY/j///9/AAn7A/0FQ0XKAAAAAElFTkSuQmCC"
-			desc = aiChat( "Describe the given image", {}, { images: [ base64Input ] } )
+			desc = aiChat( "Describe the given image", {}, { images: [ base64Input ], timeout:300 } )
 			println( "Image description: " & desc )
 			""",
 			context


### PR DESCRIPTION
# Description
This pull requests addresses Issue https://github.com/ortus-boxlang/bx-ai/issues/105 regarding implementing Image I/O within AI Providers.

Three new features have been created for the module. These are:
- Parsing of an images array when inputted into the options array parameter
- A new returnFormat "images" that returns the base64 of the generated image.
- A new wrapper function aiImage() that by default returns the base64 of the generated image, and has a optional parameter to store the image to disk at a specified path.

The features are parsed by the provider classes through the supportsImageGeneration() and supportsImageInput() functions, which individual providers can override whenever image generation logic is implemented for them (they default to false if not ovverriden from the BaseService class). 

To accompany these features, Image I/O support was implemented for OpenAI. In order to achieve Image I/O, the OpenAIService class contains logic for switching from the Chat API to the Responses API when Image I/O is detected, which was necessary as the Chat API did not support Image I/O. 
When returnFormat "image" is utilized, a "image_generation" tool is injected into the datapacket before sending the request to trigger OpenAI's Built-in tool.

Finally, tests in the OpenAI unit test were added to test for Image I/O.

All test cases within the OpenAI unit test pass.
Running all tests returns 87 failed, however, running all tests from before any of the PR changes have 88 fail (Note: For both runs, only the OpenAI key was available). These failures are not a result of the PR changes. 

## Jira/Github Issues
BoxLang Jira: N/A
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues/105

## Type of change
-   [x] New Feature
-   [x] This change requires a documentation update
In specific, the README may want to display the ability for Image I/O.

## Checklist

-   [?] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
NOTE: running box run-script format returns a message saying "The script [format] does not exist in this package." 
Therefore, I cannot verify if the .ccformat.json is followed.
However, ./gradlew spotlessCheck (for Java style guidelines) ran and passed.

-   [x] I have commented my code, particularly in hard-to-understand areas
-   [] I have made corresponding changes to the documentation
NOTE: It is unclear whether the README should reflect these new features (Especially since only OpenAI has Image I/O Implementation) . Do reply if so, then we will get right on that.

-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
