### PR TITLE
Replace interface-based capability detection with explicit static dec…

### DIFF
--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -114,12 +114,17 @@ abstract class implements="IAiService" {
 
 	/**
 	 * Returns all capabilities this provider supports.
-	 * Derived from the interfaces the provider implements — always in sync,
-	 * nothing to maintain manually.
+	 * If the concrete class overrides getDeclaredCapabilities(), that result is used.
+	 * Otherwise capabilities are inferred from implemented interfaces.
 	 *
 	 * @return Array of capability strings
 	 */
 	public array function getCapabilities() {
+		var declared = getDeclaredCapabilities()
+		if ( !declared.isEmpty() ) {
+			return declared
+		}
+		// Fallback: infer from interfaces
 		var caps = []
 		if ( isInstanceOf( this, "IAiChatService" ) ) {
 			caps.append( "chat" )
@@ -143,18 +148,17 @@ abstract class implements="IAiService" {
 	 * @return boolean
 	 */
 	public boolean function hasCapability( required string capability ) {
-		switch ( arguments.capability ) {
-			case "chat":
-			case "stream":
-				return isInstanceOf( this, "IAiChatService" )
-			case "embeddings":
-				return isInstanceOf( this, "IAiEmbeddingsService" )
-			case "transcribe":
-			case "speak":
-				return isInstanceOf( this, "IAudioService" )
-			default:
-				return false
-		}
+		return getCapabilities().findNoCase( arguments.capability ) > 0
+	}
+
+	/**
+	 * Override in concrete providers to declare explicit capabilities via static.CAPABILITIES.
+	 * Returning a non-empty array bypasses interface-based detection entirely.
+	 *
+	 * @return Array of capability strings, or [] to use interface detection
+	 */
+	public array function getDeclaredCapabilities() {
+		return []
 	}
 
 	/**

--- a/src/main/bx/models/providers/BedrockService.bx
+++ b/src/main/bx/models/providers/BedrockService.bx
@@ -66,6 +66,7 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			"model"      : "anthropic.claude-3-sonnet-20240229-v1:0",
 			"max_tokens" : 4096
@@ -90,6 +91,11 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 		loadAwsCredentialsFromEnvironment();
 
 		return this;
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/ClaudeService.bx
+++ b/src/main/bx/models/providers/ClaudeService.bx
@@ -21,6 +21,7 @@ class extends="BaseService" implements="IAiChatService" {
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream" ]
 		DEFAULT_CHAT_PARAMS = {
 			// according to the docs, this is the default model and tokens
 			// https://docs.anthropic.com/en/docs/about-claude/models/overview#model-aliases
@@ -41,6 +42,11 @@ class extends="BaseService" implements="IAiChatService" {
 		variables.name = "Claude"
 		// https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview
 		addHeader( name: "anthropic-version", value: static.DEFAULT_HEADERS[ "anthropic-version" ] )
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/CohereService.bx
+++ b/src/main/bx/models/providers/CohereService.bx
@@ -27,6 +27,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://docs.cohere.com/docs/models
 			"model" : "command-a-03-2025"
@@ -45,6 +46,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://api.cohere.com/v1/chat"
 		variables.embeddingsURL = "https://api.cohere.com/v1/embed"
 		variables.name = "Cohere"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/DeepSeekService.bx
+++ b/src/main/bx/models/providers/DeepSeekService.bx
@@ -22,6 +22,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// according to the docs, this is the default model
 			"model" : "deepseek-chat"
@@ -35,6 +36,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://api.deepseek.com/v1/chat/completions"
 		variables.embeddingsURL = "https://api.deepseek.com/v1/embeddings"
 		variables.name = "DeepSeek"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/GeminiService.bx
+++ b/src/main/bx/models/providers/GeminiService.bx
@@ -23,6 +23,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://ai.google.dev/gemini-api/docs/quickstart
 			// according to the docs, this is the default model
@@ -40,6 +41,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://generativelanguage.googleapis.com/v1beta/models/%MODEL%:generateContent"
 		variables.embeddingsURL = "https://generativelanguage.googleapis.com/v1beta/models/%MODEL%:embedContent"
 		variables.name = "Gemini"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/GrokService.bx
+++ b/src/main/bx/models/providers/GrokService.bx
@@ -21,6 +21,7 @@ class extends="OpenAIService" implements="IAiChatService" {
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream" ]
 		DEFAULT_CHAT_PARAMS = {
 			// according to the docs, this is the default model
 			// https://docs.x.ai/docs/models
@@ -35,6 +36,11 @@ class extends="OpenAIService" implements="IAiChatService" {
 		variables.chatURL = "https://api.x.ai/v1/chat/completions"
 		variables.embeddingsURL = "https://api.x.ai/v1/embeddings"
 		variables.name = "Grok"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/GroqService.bx
+++ b/src/main/bx/models/providers/GroqService.bx
@@ -21,6 +21,7 @@ class extends="OpenAIService" implements="IAiChatService" {
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://console.groq.com/docs/models
 			// according to the docs, this is a fast, efficient model
@@ -35,6 +36,11 @@ class extends="OpenAIService" implements="IAiChatService" {
 	function init(){
 		variables.chatURL = "https://api.groq.com/openai/v1/chat/completions"
 		variables.name = "Groq"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/HuggingFaceService.bx
+++ b/src/main/bx/models/providers/HuggingFaceService.bx
@@ -28,6 +28,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// Default to Qwen 2.5 which is a popular model available on HuggingFace
 			// Users can override with any model available via HuggingFace's inference providers
@@ -47,6 +48,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://router.huggingface.co/v1/chat/completions"
 		variables.embeddingsURL = "https://router.huggingface.co/hf-inference/models/sentence-transformers/all-MiniLM-L6-v2/pipeline/feature-extraction"
 		variables.name = "HuggingFace"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/MiniMaxService.bx
+++ b/src/main/bx/models/providers/MiniMaxService.bx
@@ -24,6 +24,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://platform.minimax.io/docs/api-reference/chat-completion
 			"model" : "MiniMax-M2.5-highspeed"
@@ -41,6 +42,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://api.minimax.io/v1/chat/completions"
 		variables.embeddingsURL = "https://api.minimax.io/v1/embeddings"
 		variables.name = "MiniMax"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/MistralService.bx
+++ b/src/main/bx/models/providers/MistralService.bx
@@ -24,6 +24,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://docs.mistral.ai/getting-started/models/models_overview/
 			// mistral-small-latest is the default model for cost-effective tasks
@@ -43,6 +44,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://api.mistral.ai/v1/chat/completions"
 		variables.embeddingsURL = "https://api.mistral.ai/v1/embeddings"
 		variables.name = "Mistral"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/OllamaService.bx
+++ b/src/main/bx/models/providers/OllamaService.bx
@@ -23,6 +23,7 @@ class extends="OpenAiService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// Popular local models - users can override with any Ollama model
 			"model" : "qwen2.5:0.5b-instruct"
@@ -44,6 +45,11 @@ class extends="OpenAiService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.name = "Ollama"
 		// Ollama typically doesn't require auth headers for local instances
 		// But supports basic auth for remote/secured instances
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/OpenAICompatibleService.bx
+++ b/src/main/bx/models/providers/OpenAICompatibleService.bx
@@ -60,6 +60,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_BASE_URL = "http://localhost:8080/v1"
 		DEFAULT_CHAT_PARAMS = {}
 		DEFAULT_EMBED_PARAMS = {}
@@ -75,6 +76,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.name = "OpenAICompatible"
 
 		defaults( static.DEFAULT_CHAT_PARAMS )
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -28,6 +28,7 @@ class extends="BaseService" implements="IAiChatService, IAiEmbeddingsService" {
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://platform.openai.com/docs/models
 			// according to the docs, this is the default model
@@ -46,6 +47,11 @@ class extends="BaseService" implements="IAiChatService, IAiEmbeddingsService" {
 		variables.chatURL = "https://api.openai.com/v1/chat/completions"
 		variables.embeddingsURL = "https://api.openai.com/v1/embeddings"
 		variables.name = "OpenAI"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	/**

--- a/src/main/bx/models/providers/OpenRouterService.bx
+++ b/src/main/bx/models/providers/OpenRouterService.bx
@@ -22,6 +22,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://openrouter.ai/docs/quickstart
 			// according to the docs, this is the default model
@@ -37,6 +38,11 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		variables.chatURL = "https://openrouter.ai/api/v1/chat/completions"
 		variables.embeddingsURL = "https://openrouter.ai/api/v1/embeddings"
 		variables.name = "OpenRouter"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/PerplexityService.bx
+++ b/src/main/bx/models/providers/PerplexityService.bx
@@ -21,6 +21,7 @@ class extends="OpenAIService" implements="IAiChatService" {
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "chat", "stream" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://docs.perplexity.ai/getting-started/models
 			// according to the docs, this is the default model
@@ -35,6 +36,11 @@ class extends="OpenAIService" implements="IAiChatService" {
 	function init(){
 		variables.chatURL = "https://api.perplexity.ai/chat/completions"
 		variables.name = "Perplexity"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override

--- a/src/main/bx/models/providers/VoyageService.bx
+++ b/src/main/bx/models/providers/VoyageService.bx
@@ -24,6 +24,7 @@ class extends="BaseService" implements="IAiEmbeddingsService" {
 	 * Static defaults
 	 */
 	static {
+		CAPABILITIES = [ "embeddings" ]
 		DEFAULT_EMBED_PARAMS = {
 			// voyage-3 is the latest and most capable model
 			"model" : "voyage-3"
@@ -36,6 +37,11 @@ class extends="BaseService" implements="IAiEmbeddingsService" {
 	function init(){
 		variables.embeddingsURL = "https://api.voyageai.com/v1/embeddings"
 		variables.name = "Voyage"
+	}
+
+	@override
+	public array function getDeclaredCapabilities() {
+		return static.CAPABILITIES
 	}
 
 	@override


### PR DESCRIPTION
…larations

Each provider now declares a static CAPABILITIES array and overrides getDeclaredCapabilities() to return it. BaseService.getCapabilities() uses this declaration when present, falling back to isInstanceOf() detection only if no declaration exists.

This fixes Perplexity incorrectly reporting embeddings: since it extends OpenAIService (which implements IAiEmbeddingsService), the interface check returned true even though Perplexity does not support embeddings. The static declaration is per-class and is not inherited, so Perplexity can now correctly declare CAPABILITIES = ["chat", "stream"].

hasCapability() is also simplified to delegate to getCapabilities(), eliminating the duplicate interface-checking logic.

https://claude.ai/code/session_01MywyLM9GkjfP7RarVxKTLW

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
