### PR TITLE
Fix agentName called as function instead of property accessor

### DIFF
--- a/src/main/bx/models/runnables/AiAgent.bx
+++ b/src/main/bx/models/runnables/AiAgent.bx
@@ -218,7 +218,7 @@ class extends="AiBaseRunnable" {
 		var userId         = arguments.options.userId ?: variables.options.userId ?: ""
 		var conversationId = arguments.options.conversationId ?: variables.options.conversationId ?: ""
 		// unique ID for this specific run, useful for logging and correlation
-		var runId 		= "#agentName().slugify()#-#createUUID()#"
+		var runId 		= "#getAgentName().slugify()#-#createUUID()#"
 
 		// -------------------------------------------------------------------------------------------
 		// --- Prep Message Context ---


### PR DESCRIPTION
Use getAgentName() instead of agentName() to properly access the agentName string property, which is not a function.

https://claude.ai/code/session_0199NnCrFhWYWokqCQQ4W9FP

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
