### PR TITLE
fix: add missing anthropic-version header to Claude chat() method

### DIFF
--- a/src/main/bx/models/providers/ClaudeService.bx
+++ b/src/main/bx/models/providers/ClaudeService.bx
@@ -380,6 +380,7 @@ class extends="BaseService" implements="IAiChatService" {
 		arguments.chatRequest
 			.setSendAuthHeader( false )
 			.addHeader( "x-api-key", arguments.chatRequest.getApiKey() )
+			.addHeader( "anthropic-version", getHeaders()[ "anthropic-version" ] )
 
 		// Build the packet according to Claude's API requirements
 		// https://docs.anthropic.com/en/api/messages#body-messages


### PR DESCRIPTION
The chat() method was not including the anthropic-version header in sendChatRequest() calls, causing 'anthropic-version: header is required' errors. The chatStream() method already handled this correctly by explicitly reading from getHeaders(). This aligns chat() to do the same.

https://claude.ai/code/session_015mgutMu4KExDRNkTY2msB3

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
