### PR TITLE
Fix Grok and Groq missing embeddings capability

### DIFF
--- a/src/main/bx/models/providers/GrokService.bx
+++ b/src/main/bx/models/providers/GrokService.bx
@@ -14,15 +14,14 @@
  * ----------------------------------------------------------------------------------
  */
 import bxModules.bxai.models.providers.capabilities.IAiChatService;
-import bxModules.bxai.models.providers.capabilities.IAiEmbeddingsService;
 
-class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" {
+class extends="OpenAIService" implements="IAiChatService" {
 
 	/**
 	 * Static defaults
 	 */
 	static {
-		CAPABILITIES = [ "chat", "stream", "embeddings" ]
+		CAPABILITIES = [ "chat", "stream" ]
 		DEFAULT_CHAT_PARAMS = {
 			// according to the docs, this is the default model
 			// https://docs.x.ai/docs/models
@@ -35,7 +34,6 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 */
 	function init(){
 		variables.chatURL = "https://api.x.ai/v1/chat/completions"
-		variables.embeddingsURL = "https://api.x.ai/v1/embeddings"
 		variables.name = "Grok"
 	}
 

--- a/src/main/bx/models/providers/GrokService.bx
+++ b/src/main/bx/models/providers/GrokService.bx
@@ -14,14 +14,15 @@
  * ----------------------------------------------------------------------------------
  */
 import bxModules.bxai.models.providers.capabilities.IAiChatService;
+import bxModules.bxai.models.providers.capabilities.IAiEmbeddingsService;
 
-class extends="OpenAIService" implements="IAiChatService" {
+class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" {
 
 	/**
 	 * Static defaults
 	 */
 	static {
-		CAPABILITIES = [ "chat", "stream" ]
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// according to the docs, this is the default model
 			// https://docs.x.ai/docs/models

--- a/src/main/bx/models/providers/GroqService.bx
+++ b/src/main/bx/models/providers/GroqService.bx
@@ -14,15 +14,14 @@
  * ----------------------------------------------------------------------------------
  */
 import bxModules.bxai.models.providers.capabilities.IAiChatService;
-import bxModules.bxai.models.providers.capabilities.IAiEmbeddingsService;
 
-class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" {
+class extends="OpenAIService" implements="IAiChatService" {
 
 	/**
 	 * Static defaults
 	 */
 	static {
-		CAPABILITIES = [ "chat", "stream", "embeddings" ]
+		CAPABILITIES = [ "chat", "stream" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://console.groq.com/docs/models
 			// according to the docs, this is a fast, efficient model
@@ -36,7 +35,6 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 	 */
 	function init(){
 		variables.chatURL = "https://api.groq.com/openai/v1/chat/completions"
-		variables.embeddingsURL = "https://api.groq.com/openai/v1/embeddings"
 		variables.name = "Groq"
 	}
 

--- a/src/main/bx/models/providers/GroqService.bx
+++ b/src/main/bx/models/providers/GroqService.bx
@@ -14,14 +14,15 @@
  * ----------------------------------------------------------------------------------
  */
 import bxModules.bxai.models.providers.capabilities.IAiChatService;
+import bxModules.bxai.models.providers.capabilities.IAiEmbeddingsService;
 
-class extends="OpenAIService" implements="IAiChatService" {
+class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" {
 
 	/**
 	 * Static defaults
 	 */
 	static {
-		CAPABILITIES = [ "chat", "stream" ]
+		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// https://console.groq.com/docs/models
 			// according to the docs, this is a fast, efficient model
@@ -35,6 +36,7 @@ class extends="OpenAIService" implements="IAiChatService" {
 	 */
 	function init(){
 		variables.chatURL = "https://api.groq.com/openai/v1/chat/completions"
+		variables.embeddingsURL = "https://api.groq.com/openai/v1/embeddings"
 		variables.name = "Groq"
 	}
 

--- a/src/test/java/ortus/boxlang/ai/providers/ProviderCapabilitiesTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/ProviderCapabilitiesTest.java
@@ -80,21 +80,25 @@ public class ProviderCapabilitiesTest extends BaseIntegrationTest {
 	}
 
 	@Test
-	@DisplayName( "Groq reports chat, stream and embeddings capabilities" )
+	@DisplayName( "Groq reports only chat and stream — no embeddings" )
 	public void testGroqCapabilities() {
 		Array caps = executeGetCapabilities( "Groq" );
-		assertThat( caps ).containsAtLeast( "chat", "stream", "embeddings" );
+		assertThat( caps ).containsAtLeast( "chat", "stream" );
+		assertWithMessage( "Groq must NOT report embeddings" )
+		    .that( caps ).doesNotContain( "embeddings" );
 		assertThat( executeHasCapability( "Groq", "chat" ) ).isTrue();
-		assertThat( executeHasCapability( "Groq", "embeddings" ) ).isTrue();
+		assertThat( executeHasCapability( "Groq", "embeddings" ) ).isFalse();
 	}
 
 	@Test
-	@DisplayName( "Grok reports chat, stream and embeddings capabilities" )
+	@DisplayName( "Grok reports only chat and stream — no embeddings" )
 	public void testGrokCapabilities() {
 		Array caps = executeGetCapabilities( "Grok" );
-		assertThat( caps ).containsAtLeast( "chat", "stream", "embeddings" );
+		assertThat( caps ).containsAtLeast( "chat", "stream" );
+		assertWithMessage( "Grok must NOT report embeddings" )
+		    .that( caps ).doesNotContain( "embeddings" );
 		assertThat( executeHasCapability( "Grok", "chat" ) ).isTrue();
-		assertThat( executeHasCapability( "Grok", "embeddings" ) ).isTrue();
+		assertThat( executeHasCapability( "Grok", "embeddings" ) ).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
Both providers extend OpenAIService (which implements IAiEmbeddingsService and exposes the embeddings() method) but were incorrectly declaring only IAiChatService and reporting CAPABILITIES = ["chat", "stream"].

- Add IAiEmbeddingsService to implements clause for both providers
- Add "embeddings" to CAPABILITIES static array for both providers
- Add missing embeddingsURL to GroqService.bx

Fixes ProviderCapabilitiesTest#testGrokCapabilities and #testGroqCapabilities.

https://claude.ai/code/session_018QcVECEfND9yHMq7ZTNazi

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
