### PR TITLE
fix: merge service defaults in ClaudeService.chat() and chatStream()

### DIFF
--- a/src/main/bx/models/providers/ClaudeService.bx
+++ b/src/main/bx/models/providers/ClaudeService.bx
@@ -84,6 +84,14 @@ class extends="BaseService" implements="IAiChatService" {
 	 */
 	@override
 	public function chatStream( required AiChatRequest chatRequest, required function callback, numeric interactionCount = 0 ){
+		// Apply service-level defaults so model is always set
+		arguments.chatRequest
+			.mergeServiceParams( static.DEFAULT_CHAT_PARAMS )
+			.setModelIfEmpty( variables.params.model ?: "" )
+			.setApiKeyIfEmpty( getAPIKey() )
+			.mergeServiceParams( variables.params )
+			.mergeServiceHeaders( variables.headers );
+
 		var userCallback = arguments.callback;
 		var thisChatRequest = arguments.chatRequest;
 
@@ -376,6 +384,14 @@ class extends="BaseService" implements="IAiChatService" {
 	 */
 	@override
 	public function chat( required AiChatRequest chatRequest, numeric interactionCount = 0 ){
+		// Apply service-level defaults so model is always set
+		arguments.chatRequest
+			.mergeServiceParams( static.DEFAULT_CHAT_PARAMS )
+			.setModelIfEmpty( variables.params.model ?: "" )
+			.setApiKeyIfEmpty( getAPIKey() )
+			.mergeServiceParams( variables.params )
+			.mergeServiceHeaders( variables.headers );
+
 		// No auth header, claude uses x-api-key
 		arguments.chatRequest
 			.setSendAuthHeader( false )


### PR DESCRIPTION
Both chat() and chatStream() were not applying service-level default params (including the default model) before building the request packet. When no model was explicitly passed by the caller, getModel() returned an empty string, causing the Claude API to reject the request with "model: String should have at least 1 character".

Align with OpenAIService pattern: merge DEFAULT_CHAT_PARAMS, call setModelIfEmpty, setApiKeyIfEmpty, and merge service params/headers at the top of both methods.

https://claude.ai/code/session_01UEaGCzDxdon6RGAES3qTYL

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
