### PR TITLE
feat: async subagent delegation via runAsync() and AiRunnableParallel

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`runAsync()` on all runnables** (`IAiRunnable`, `AiBaseRunnable`): Every runnable now has a non-blocking `runAsync(input, params, options)` method that dispatches execution to the `io-tasks` virtual thread pool and returns a `BoxFuture`. Mirrors the existing `aiChatAsync`, `loadAsync()`, and `seedAsync()` patterns throughout the module.
+- **`AiRunnableParallel` class** (`models/runnables/AiRunnableParallel.bx`): New runnable that accepts a named struct of runnables, fans them out concurrently via `runAsync()`, and returns a `{ name: result }` struct once all futures complete. Mirrors LangChain's `RunnableParallel` — a structural parallel composition primitive that integrates cleanly into the existing pipeline system via `.to()`, `.run()`, and `.runAsync()`.
+- **`aiParallel()` BIF**: Creates an `AiRunnableParallel` from a named struct of runnables. `aiParallel({ summary: summaryAgent, analysis: analysisAgent }).run("document")` runs both concurrently and returns `{ summary: "...", analysis: "..." }`.
+
 ## [3.0.0] - 2026-04-02
 
 ## [2.4.0] - 2026-02-20

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Welcome to the **BoxLang AI Module** 🚀 The official AI library for BoxLang th
 - 📡 **MCP Protocol** - Build and consume Model Context Protocol servers for distributed AI
 - 💬 **Fluent Interface** - Chainable, expressive syntax that makes AI integration intuitive
 - 🦙 **Local AI** - Full Ollama support for privacy, offline use, and zero API costs
-- ⚡ **Async Operations** - Non-blocking futures for concurrent AI requests
+- ⚡ **Async Operations** - Non-blocking `runAsync()` on every runnable; `aiParallel()` for concurrent parallel pipelines
 - 🎯 **Event-Driven** - 35+ lifecycle events for logging, monitoring, and custom workflows
 - 🏭 **Production-Ready** - Timeout controls, error handling, rate limiting, and debugging tools
 - 🧪 **Testable** - Deterministic replay for reliable unit and integration testing
@@ -505,6 +505,34 @@ class implements="IAiRunnable" {
 customStage = new CustomRunnable()
 pipeline = aiModel( provider: "openai", params: { model: "gpt-4o" } )
 	.to( customStage )
+```
+
+**Parallel Pipelines:**
+
+Run multiple runnables concurrently with the same input and receive a named struct of results. Mirrors LangChain's `RunnableParallel` — parallelism is a developer/framework concern, not something the LLM decides.
+
+```javascript
+// Fan out to multiple agents/models in parallel
+results = aiParallel({
+    summary:  summaryAgent,
+    analysis: analysisAgent,
+    keywords: keywordModel
+}).run( "Some long document..." )
+
+// results.summary, results.analysis, results.keywords — all ran concurrently
+
+// Compose in a pipeline — parallel branch then merge
+pipeline = aiMessage( "Analyze: ${text}" )
+    .to( aiParallel({ researcher: researchAgent, writer: writerAgent }) )
+    .transform( r => "Research: #r.researcher#\nDraft: #r.writer#" )
+
+// Or dispatch the same agent for multiple independent inputs asynchronously
+futures = [
+    researchAgent.runAsync( "Topic A" ),
+    researchAgent.runAsync( "Topic B" ),
+    researchAgent.runAsync( "Topic C" )
+]
+results = futures.map( f => f.get() )
 ```
 
 #### 📚 Learn More
@@ -1870,7 +1898,7 @@ Here are the settings you can place in your `boxlang.json` file:
 
 | Function | Purpose | Parameters | Return Type | Async Support |
 |----------|---------|------------|-------------|---------------|
-| `aiAgent()` | Create autonomous AI agent | `name`, `description`, `instructions`, `model`, `memory`, `tools`, `subAgents`, `params`, `options`, `mcpServers=[]`, `skills=[]`, `availableSkills=[]` | AiAgent Object | ❌ |
+| `aiAgent()` | Create autonomous AI agent | `name`, `description`, `instructions`, `model`, `memory`, `tools`, `subAgents`, `params`, `options`, `mcpServers=[]`, `skills=[]`, `availableSkills=[]` | AiAgent Object (supports `runAsync()`) | ✅ |
 | `aiChat()` | Chat with AI provider | `messages`, `params={}`, `options={}` | String/Array/Struct | ❌ |
 | `aiChatAsync()` | Async chat with AI provider | `messages`, `params={}`, `options={}` | BoxLang Future | ✅ |
 | `aiChatRequest()` | Compose a reusable chat request object (useful for advanced pipelines and middleware) | `messages`, `params`, `options`, `headers` | AiChatRequest Object | N/A |
@@ -1888,6 +1916,7 @@ Here are the settings you can place in your `boxlang.json` file:
 | `aiTokens()` | Estimate token count for a text string | `text`, `options={}` _(method: characters\|words)_ | Numeric | N/A |
 | `aiTool()` | Create tool for real-time processing | `name`, `description`, `callable` | Tool Object | N/A |
 | `aiToolRegistry()` | Get the singleton AI Tool Registry | _(none)_ | AIToolRegistry Object | N/A |
+| `aiParallel()` | Run multiple named runnables concurrently and collect results | `runnables` (struct of `{ name: IAiRunnable }`) | AiRunnableParallel Object | ✅ (via `runAsync()`) |
 | `aiTransform()` | Create data transformer | `transformer`, `config={}` | Transformer Runnable | N/A |
 | `MCP()` | Create MCP client for Model Context Protocol servers | `baseURL` | MCPClient Object | N/A |
 | `mcpServer()` | Get or create MCP server for exposing tools | `name="default"`, `description`, `version`, `cors`, `statsEnabled`, `force` | MCPServer Object | N/A |

--- a/src/main/bx/bifs/aiParallel.bx
+++ b/src/main/bx/bifs/aiParallel.bx
@@ -43,7 +43,7 @@ class {
 	 * @return AiRunnableParallel instance ready to call run() or chain with .to()
 	 */
 	function invoke( required struct runnables ) {
-		return new bxModules.bxai.models.runnables.AiRunnableParallel( arguments.runnables );
+		return new bxModules.bxai.models.runnables.AiRunnableParallel( arguments.runnables )
 	}
 
 }

--- a/src/main/bx/bifs/aiParallel.bx
+++ b/src/main/bx/bifs/aiParallel.bx
@@ -1,0 +1,49 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * ----------------------------------------------------------------------------------
+ * Create an AiRunnableParallel that executes multiple named runnables concurrently.
+ */
+@BoxBIF
+class {
+
+	/**
+	 * Create an AiRunnableParallel that executes multiple named runnables concurrently.
+	 * <p>
+	 * Each runnable receives the same input when run() is called; all execute concurrently
+	 * via runAsync() on the io-tasks virtual thread pool; results are returned as a named
+	 * struct once all futures complete. Mirrors LangChain's RunnableParallel pattern.
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * results = aiParallel({
+	 *     summary:  summaryAgent,
+	 *     analysis: analysisAgent
+	 * }).run( "some document" )
+	 * // results.summary and results.analysis ran concurrently
+	 *
+	 * // Or compose in a pipeline with merge step:
+	 * pipeline = aiMessage( "Analyze: ${text}" )
+	 *     .to( aiParallel({ researcher: researchAgent, writer: writerAgent }) )
+	 *     .transform( r => "Research: #r.researcher#\nDraft: #r.writer#" )
+	 * </pre>
+	 *
+	 * @runnables Struct of { name: IAiRunnable } pairs. Each key becomes a key in the result struct.
+	 *
+	 * @return AiRunnableParallel instance ready to call run() or chain with .to()
+	 */
+	function invoke( required struct runnables ) {
+		return new bxModules.bxai.models.runnables.AiRunnableParallel( arguments.runnables );
+	}
+
+}

--- a/src/main/bx/models/runnables/AiBaseRunnable.bx
+++ b/src/main/bx/models/runnables/AiBaseRunnable.bx
@@ -108,6 +108,25 @@ abstract class implements="IAiRunnable" {
     }
 
 	/**
+	 * Run the operation asynchronously on the io-tasks virtual thread pool.
+	 * Returns immediately with a BoxFuture that resolves to the operation result.
+	 * Pattern mirrors aiChatAsync, loadAsync(), and seedAsync() in this module.
+	 *
+	 * @input   The input to process, empty struct if none
+	 * @params  Optional parameters to configure the operation
+	 * @options Optional runtime options (returnFormat, timeout, logging, etc.)
+	 *
+	 * @return A BoxFuture that resolves to the result of the operation
+	 */
+	public BoxFuture function runAsync(
+		any input = {},
+		struct params = {},
+		struct options = {}
+	) {
+		return asyncRun( () => this.run( input, params, options ), "io-tasks" );
+	}
+
+	/**
 	 * Chain this runnable with another runnable
 	 * Creates a sequence that will execute this runnable followed by the next
      *

--- a/src/main/bx/models/runnables/AiBaseRunnable.bx
+++ b/src/main/bx/models/runnables/AiBaseRunnable.bx
@@ -123,7 +123,7 @@ abstract class implements="IAiRunnable" {
 		struct params = {},
 		struct options = {}
 	) {
-		return asyncRun( () => this.run( input, params, options ), "io-tasks" );
+		return asyncRun( () => this.run( input, params, options ), "io-tasks" )
 	}
 
 	/**

--- a/src/main/bx/models/runnables/AiRunnableParallel.bx
+++ b/src/main/bx/models/runnables/AiRunnableParallel.bx
@@ -1,0 +1,117 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * ----------------------------------------------------------------------------------
+ * Runs multiple named runnables in parallel and returns a struct of results.
+ *
+ * Each runnable receives the same input; all execute concurrently via runAsync() on the
+ * io-tasks virtual thread pool; results are aggregated into a { name: result } struct once
+ * all futures complete. Mirrors LangChain's RunnableParallel pattern.
+ *
+ * Example:
+ * ```
+ * var parallel = aiParallel({
+ *     summary:   summaryAgent,
+ *     analysis:  analysisAgent,
+ *     sentiment: sentimentModel
+ * })
+ * var results = parallel.run( "Some document..." )
+ * // results.summary, results.analysis, results.sentiment — all ran concurrently
+ *
+ * // Compose in a pipeline — parallel branch then merge
+ * var pipeline = aiMessage( "Analyze: ${text}" )
+ *     .to( aiParallel({ researcher: researchAgent, writer: writerAgent }) )
+ *     .transform( r => "Research: #r.researcher#\nDraft: #r.writer#" )
+ * ```
+ */
+class extends="AiBaseRunnable" {
+
+	/**
+	 * Named runnables to execute in parallel.
+	 * Keys become the keys in the result struct returned by run().
+	 */
+	property name="runnables" type="struct" default={};
+
+	/**
+	 * Initialize with a named struct of runnables.
+	 *
+	 * @runnables Struct of { name: IAiRunnable } pairs
+	 *
+	 * @return This instance for chaining
+	 */
+	function init( struct runnables = {} ) {
+		variables.runnables = arguments.runnables;
+		return this;
+	}
+
+	/**
+	 * Add a named runnable to the parallel set.
+	 *
+	 * @name     The key name for this runnable's result in the output struct
+	 * @runnable The runnable to execute in parallel
+	 *
+	 * @return This instance for chaining
+	 */
+	public AiRunnableParallel function add( required string name, required IAiRunnable runnable ) {
+		variables.runnables[ arguments.name ] = arguments.runnable;
+		return this;
+	}
+
+	/**
+	 * Run all runnables concurrently with the same input.
+	 * Blocks until all futures complete and returns a struct of { name: result }.
+	 *
+	 * @input   The input passed to every runnable
+	 * @params  Optional parameters forwarded to every runnable
+	 * @options Optional runtime options forwarded to every runnable
+	 *
+	 * @return Struct of { name: result } — one entry per registered runnable
+	 */
+	public struct function run( any input = {}, struct params = {}, struct options = {} ) {
+		// Fan-out: start all runnables asynchronously on the io-tasks pool
+		var futures = {};
+		variables.runnables.each( ( name, runnable ) => {
+			futures[ name ] = runnable.runAsync( input, params, options );
+		} );
+
+		// Gather: wait for each future and collect results
+		var results = {};
+		futures.each( ( name, future ) => {
+			results[ name ] = future.get();
+		} );
+
+		return results;
+	}
+
+	/**
+	 * Streaming is not supported — parallel runnables produce a struct, not a token stream.
+	 *
+	 * @throws AiRunnableParallel.NotSupported always
+	 */
+	public void function stream( required function onChunk, any input = {}, struct params = {}, struct options = {} ) {
+		throw(
+			type    : "AiRunnableParallel.NotSupported",
+			message : "AiRunnableParallel does not support streaming. Use run() or runAsync() instead."
+		);
+	}
+
+	/**
+	 * Returns a descriptive name listing the registered runnable keys.
+	 *
+	 * @return String name
+	 */
+	public string function getName() {
+		return "AiRunnableParallel(" & variables.runnables.keyList() & ")";
+	}
+
+}

--- a/src/main/bx/models/runnables/AiRunnableParallel.bx
+++ b/src/main/bx/models/runnables/AiRunnableParallel.bx
@@ -50,8 +50,8 @@ class extends="AiBaseRunnable" {
 	 * @return This instance for chaining
 	 */
 	function init( struct runnables = {} ) {
-		variables.runnables = arguments.runnables;
-		return this;
+		variables.runnables = arguments.runnables
+		return this
 	}
 
 	/**
@@ -63,8 +63,8 @@ class extends="AiBaseRunnable" {
 	 * @return This instance for chaining
 	 */
 	public AiRunnableParallel function add( required string name, required IAiRunnable runnable ) {
-		variables.runnables[ arguments.name ] = arguments.runnable;
-		return this;
+		variables.runnables[ arguments.name ] = arguments.runnable
+		return this
 	}
 
 	/**
@@ -79,18 +79,18 @@ class extends="AiBaseRunnable" {
 	 */
 	public struct function run( any input = {}, struct params = {}, struct options = {} ) {
 		// Fan-out: start all runnables asynchronously on the io-tasks pool
-		var futures = {};
+		var futures = {}
 		variables.runnables.each( ( name, runnable ) => {
-			futures[ name ] = runnable.runAsync( input, params, options );
-		} );
+			futures[ name ] = runnable.runAsync( input, params, options )
+		} )
 
 		// Gather: wait for each future and collect results
-		var results = {};
+		var results = {}
 		futures.each( ( name, future ) => {
-			results[ name ] = future.get();
-		} );
+			results[ name ] = future.get()
+		} )
 
-		return results;
+		return results
 	}
 
 	/**
@@ -102,7 +102,7 @@ class extends="AiBaseRunnable" {
 		throw(
 			type    : "AiRunnableParallel.NotSupported",
 			message : "AiRunnableParallel does not support streaming. Use run() or runAsync() instead."
-		);
+		)
 	}
 
 	/**
@@ -111,7 +111,7 @@ class extends="AiBaseRunnable" {
 	 * @return String name
 	 */
 	public string function getName() {
-		return "AiRunnableParallel(" & variables.runnables.keyList() & ")";
+		return "AiRunnableParallel(" & variables.runnables.keyList() & ")"
 	}
 
 }

--- a/src/main/bx/models/runnables/AiRunnableParallel.bx
+++ b/src/main/bx/models/runnables/AiRunnableParallel.bx
@@ -50,7 +50,11 @@ class extends="AiBaseRunnable" {
 	 * @return This instance for chaining
 	 */
 	function init( struct runnables = {} ) {
-		variables.runnables = arguments.runnables
+		variables.runnables = {}
+
+		arguments.runnables.each( ( name, runnable ) => {
+			add( name, runnable )
+		} )
 		return this
 	}
 

--- a/src/main/bx/models/runnables/AiRunnableParallel.bx
+++ b/src/main/bx/models/runnables/AiRunnableParallel.bx
@@ -78,10 +78,13 @@ class extends="AiBaseRunnable" {
 	 * @return Struct of { name: result } — one entry per registered runnable
 	 */
 	public struct function run( any input = {}, struct params = {}, struct options = {} ) {
+		var effectiveParams	 = getMergedParams( params )
+		var effectiveOptions = getMergedOptions( options )
+
 		// Fan-out: start all runnables asynchronously on the io-tasks pool
 		var futures = {}
 		variables.runnables.each( ( name, runnable ) => {
-			futures[ name ] = runnable.runAsync( input, params, options )
+			futures[ name ] = runnable.runAsync( input, effectiveParams, effectiveOptions )
 		} )
 
 		// Gather: wait for each future and collect results

--- a/src/main/bx/models/runnables/IAiRunnable.bx
+++ b/src/main/bx/models/runnables/IAiRunnable.bx
@@ -47,6 +47,25 @@ interface {
 		struct options = {}
 	);
 
+	/**
+	 * Run the operation asynchronously on the io-tasks virtual thread pool.
+	 * Returns immediately with a BoxFuture that resolves to the operation result.
+	 * Pattern mirrors aiChatAsync, loadAsync(), and seedAsync() in this module.
+	 *
+	 * @input   The input to process
+	 * @params  Optional parameters to configure the operation
+	 * @options Optional runtime options (returnFormat, timeout, logging, etc.)
+	 *
+	 * @return A BoxFuture that resolves to the result of the operation
+	 */
+	default BoxFuture function runAsync(
+		any input = {},
+		struct params = {},
+		struct options = {}
+	) {
+		return asyncRun( () => this.run( input, params, options ), "io-tasks" );
+	}
+
     /**
      * Get the name of the runnable
      *

--- a/src/main/bx/models/runnables/IAiRunnable.bx
+++ b/src/main/bx/models/runnables/IAiRunnable.bx
@@ -63,7 +63,7 @@ interface {
 		struct params = {},
 		struct options = {}
 	) {
-		return asyncRun( () => this.run( input, params, options ), "io-tasks" );
+		return asyncRun( () => this.run( input, params, options ), "io-tasks" )
 	}
 
     /**

--- a/src/test/java/ortus/boxlang/ai/bifs/aiAgentTest.java
+++ b/src/test/java/ortus/boxlang/ai/bifs/aiAgentTest.java
@@ -973,4 +973,115 @@ public class aiAgentTest extends BaseIntegrationTest {
 		assertFalse( variables.getAsBoolean( Key.of( "hasLoadTool" ) ) );
 	}
 
+	// ==================== ASYNC TESTS ====================
+
+	@Test
+	@DisplayName( "runAsync() on an agent returns a non-null BoxFuture" )
+	public void testAgentRunAsyncReturnsFuture() {
+		runtime.executeSource(
+		    """
+		    agent  = aiAgent( name: "AsyncAgent", description: "Async test agent" )
+		    future = agent.runAsync( "Hello" )
+		    isFuture = !isNull( future )
+		    """,
+		    context
+		);
+
+		assertTrue( variables.getAsBoolean( Key.of( "isFuture" ) ) );
+	}
+
+	@Test
+	@DisplayName( "runAsync() on an AiModel returns a non-null BoxFuture" )
+	public void testModelRunAsyncReturnsFuture() {
+		runtime.executeSource(
+		    """
+		    model    = aiModel()
+		    future   = model.runAsync( "Hello" )
+		    isFuture = !isNull( future )
+		    """,
+		    context
+		);
+
+		assertTrue( variables.getAsBoolean( Key.of( "isFuture" ) ) );
+	}
+
+	@Test
+	@DisplayName( "aiParallel() BIF creates an AiRunnableParallel instance" )
+	public void testAiParallelBIFCreatesRunnableParallel() {
+		runtime.executeSource(
+		    """
+		    agentA   = aiAgent( name: "AgentA", description: "First agent" )
+		    agentB   = aiAgent( name: "AgentB", description: "Second agent" )
+		    parallel = aiParallel({ a: agentA, b: agentB })
+		    isParallel = parallel instanceof "bxModules.bxai.models.runnables.AiRunnableParallel"
+		    """,
+		    context
+		);
+
+		assertTrue( variables.getAsBoolean( Key.of( "isParallel" ) ) );
+	}
+
+	@Test
+	@DisplayName( "AiRunnableParallel.run() returns a struct with all named keys" )
+	public void testAiRunnableParallelRunReturnsMergedStruct() {
+		runtime.executeSource(
+		    """
+		    agentA   = aiAgent( name: "AgentA", description: "First agent" )
+		    agentB   = aiAgent( name: "AgentB", description: "Second agent" )
+		    parallel = aiParallel({ a: agentA, b: agentB })
+		    hasKeys  = parallel.getRunnables().keyExists( "a" ) && parallel.getRunnables().keyExists( "b" )
+		    """,
+		    context
+		);
+
+		assertTrue( variables.getAsBoolean( Key.of( "hasKeys" ) ) );
+	}
+
+	@Test
+	@DisplayName( "AiRunnableParallel.add() adds a named runnable and returns itself for chaining" )
+	public void testAiRunnableParallelAdd() {
+		runtime.executeSource(
+		    """
+		    agentA   = aiAgent( name: "AgentA", description: "First agent" )
+		    agentB   = aiAgent( name: "AgentB", description: "Second agent" )
+		    parallel = aiParallel({ a: agentA }).add( "b", agentB )
+		    keyCount = parallel.getRunnables().count()
+		    """,
+		    context
+		);
+
+		assertEquals( 2L, ( long ) ( ( Number ) variables.get( Key.of( "keyCount" ) ) ).intValue() );
+	}
+
+	@Test
+	@DisplayName( "AiRunnableParallel.getName() returns a descriptive string with runnable keys" )
+	public void testAiRunnableParallelGetName() {
+		runtime.executeSource(
+		    """
+		    agentA   = aiAgent( name: "AgentA", description: "First agent" )
+		    parallel = aiParallel({ summary: agentA })
+		    name     = parallel.getName()
+		    """,
+		    context
+		);
+
+		var name = ( String ) variables.get( Key.of( "name" ) );
+		assertTrue( name.contains( "summary" ) );
+	}
+
+	@Test
+	@DisplayName( "AiRunnableParallel.stream() throws AiRunnableParallel.NotSupported" )
+	public void testAiRunnableParallelStreamThrows() {
+		assertThrows( Exception.class, () -> {
+			runtime.executeSource(
+			    """
+			    agentA   = aiAgent( name: "AgentA", description: "First agent" )
+			    parallel = aiParallel({ a: agentA })
+			    parallel.stream( chunk => writeOutput( chunk ), "input" )
+			    """,
+			    context
+			);
+		} );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/ai/bifs/aiAgentTest.java
+++ b/src/test/java/ortus/boxlang/ai/bifs/aiAgentTest.java
@@ -1026,15 +1026,18 @@ public class aiAgentTest extends BaseIntegrationTest {
 	public void testAiRunnableParallelRunReturnsMergedStruct() {
 		runtime.executeSource(
 		    """
-		    agentA   = aiAgent( name: "AgentA", description: "First agent" )
-		    agentB   = aiAgent( name: "AgentB", description: "Second agent" )
-		    parallel = aiParallel({ a: agentA, b: agentB })
-		    hasKeys  = parallel.getRunnables().keyExists( "a" ) && parallel.getRunnables().keyExists( "b" )
+		    runnableA = aiTransform( input => input & "-a" )
+		    runnableB = aiTransform( input => input & "-b" )
+		    parallel  = aiParallel({ a: runnableA, b: runnableB })
+		    result    = parallel.run( "input" )
+		    hasKeys   = isStruct( result ) && result.keyExists( "a" ) && result.keyExists( "b" )
+		    hasValues = result.a == "input-a" && result.b == "input-b"
 		    """,
 		    context
 		);
 
 		assertTrue( variables.getAsBoolean( Key.of( "hasKeys" ) ) );
+		assertTrue( variables.getAsBoolean( Key.of( "hasValues" ) ) );
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- **`runAsync()` on every `IAiRunnable`** — Non-blocking async dispatch on the `io-tasks` virtual thread pool, returning a `BoxFuture`. Mirrors the existing `aiChatAsync`, `loadAsync()`, and `seedAsync()` patterns already in the module.
- **`AiRunnableParallel` class + `aiParallel()` BIF** — Structural parallel composition primitive: pass a named struct of runnables, call `.run(input)`, receive a `{ name: result }` struct once all concurrent futures complete. Mirrors LangChain's `RunnableParallel` — parallelism is expressed at composition time by the developer, not decided by the LLM at runtime.

## Design Rationale

Researched how LangChain, LangGraph, OpenAI Agents SDK, CrewAI, and AutoGen handle parallel multi-agent execution. None of them auto-register a "call multiple agents in parallel" tool for the LLM. They all treat parallelism as a **framework/orchestration concern**:

| Library | Pattern |
|---|---|
| LangChain | `RunnableParallel({"a": chainA, "b": chainB})` — structural composition |
| OpenAI Agents SDK | `asyncio.gather(Runner.run(a1), Runner.run(a2))` — explicit developer code |
| LangGraph | Multi-edge fan-out in graph topology — superstep concurrency |
| CrewAI | `Task(async_execution=True)` flag + internal gather |

## Usage

```boxlang
// 1. runAsync() — non-blocking dispatch on any runnable
future = myAgent.runAsync( "Summarize this document" )
result = future.get()

// 2. aiParallel() — concurrent fan-out with named results
results = aiParallel({
    summary:  summaryAgent,
    analysis: analysisAgent,
    keywords: keywordModel
}).run( "Some long document..." )
// results.summary, results.analysis, results.keywords — all ran concurrently

// 3. In a pipeline — parallel branch then merge
pipeline = aiMessage( "Analyze: ${text}" )
    .to( aiParallel({ researcher: researchAgent, writer: writerAgent }) )
    .transform( r => "Research: #r.researcher#\nDraft: #r.writer#" )

// 4. Same agent, multiple independent inputs
futures = [
    researchAgent.runAsync( "Topic A" ),
    researchAgent.runAsync( "Topic B" ),
    researchAgent.runAsync( "Topic C" )
]
results = futures.map( f => f.get() )
```

## Test Plan

- [ ] `testAgentRunAsyncReturnsFuture` — `agent.runAsync()` returns a non-null `BoxFuture`
- [ ] `testModelRunAsyncReturnsFuture` — `aiModel().runAsync()` returns a non-null `BoxFuture`
- [ ] `testAiParallelBIFCreatesRunnableParallel` — `aiParallel({...})` returns `AiRunnableParallel`
- [ ] `testAiRunnableParallelRunReturnsMergedStruct` — registered runnable keys are present
- [ ] `testAiRunnableParallelAdd` — `.add()` appends a runnable and returns `this` for chaining
- [ ] `testAiRunnableParallelGetName` — `getName()` includes runnable key names
- [ ] `testAiRunnableParallelStreamThrows` — `stream()` throws `AiRunnableParallel.NotSupported`