### PR TITLE
Fix/171 stream token count

### DIFF
--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -573,10 +573,11 @@ abstract class implements="IAiService" {
 			arguments.streamState.usage = arguments.parsedChunk.usage;
 		}
 
-		var firstChoice = arguments.parsedChunk.choices?.first();
-		if( isNull( firstChoice ) ){
+		var choices = arguments.parsedChunk.choices ?: [];
+		if( !isArray( choices ) || choices.isEmpty() ){
 			return;
 		}
+		var firstChoice = choices.first();
 
 		// Accumulate streamed content
 		var content = firstChoice.delta?.content ?: "";

--- a/src/main/bx/models/providers/BaseService.bx
+++ b/src/main/bx/models/providers/BaseService.bx
@@ -435,7 +435,8 @@ abstract class implements="IAiService" {
 		var streamState = {
 			"content": "",
 			"finishReason": "",
-			"toolCalls": []
+			"toolCalls": [],
+			"usage": {}
 		};
 
 		// Announce the request
@@ -567,6 +568,11 @@ abstract class implements="IAiService" {
 	 * @return void
 	 */
 	private void function updateStreamState( required struct streamState, required struct parsedChunk ){
+		// Capture usage from final chunk (arrives with empty choices when stream_options.include_usage is true)
+		if( arguments.parsedChunk.keyExists( "usage" ) && isStruct( arguments.parsedChunk.usage ) && !structIsEmpty( arguments.parsedChunk.usage ) ){
+			arguments.streamState.usage = arguments.parsedChunk.usage;
+		}
+
 		var firstChoice = arguments.parsedChunk.choices?.first();
 		if( isNull( firstChoice ) ){
 			return;

--- a/src/main/bx/models/providers/BedrockService.bx
+++ b/src/main/bx/models/providers/BedrockService.bx
@@ -1018,12 +1018,42 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 
 		// Parse the AWS event-stream binary response
 		// The response contains multiple events, each with a binary header and JSON payload
+		var bedrockUsage = { "inputTokens": 0, "outputTokens": 0, "totalTokens": 0, "raw": {} };
+		var userStreamCallback = arguments.callback;
+		var usageCapturingCallback = ( chunk ) => {
+			// Capture usage data from the normalized chunk if present
+			if( !isNull( chunk.usage ) && isStruct( chunk.usage ) ){
+				bedrockUsage.inputTokens  = chunk.usage.keyExists( "prompt_tokens" )     ? chunk.usage.prompt_tokens     : bedrockUsage.inputTokens;
+				bedrockUsage.outputTokens = chunk.usage.keyExists( "completion_tokens" ) ? chunk.usage.completion_tokens : bedrockUsage.outputTokens;
+				bedrockUsage.totalTokens  = bedrockUsage.inputTokens + bedrockUsage.outputTokens;
+				bedrockUsage.raw          = chunk.usage;
+			}
+			userStreamCallback( chunk );
+		};
+
 		parseBedrockEventStream(
 			httpResult.fileContent,
 			arguments.modelFamily,
 			arguments.modelId,
-			arguments.callback
+			usageCapturingCallback
 		);
+
+		// -------------------------------------------------------------------------------------------
+		// --- Usage Event Announcement (Streaming) ---
+		// -------------------------------------------------------------------------------------------
+		if( bedrockUsage.totalTokens > 0 ){
+			boxAnnounce( "onAITokenCount", {
+				provider         : this,
+				operation        : "stream",
+				model            : arguments.modelId,
+				promptTokens     : bedrockUsage.inputTokens,
+				completionTokens : bedrockUsage.outputTokens,
+				totalTokens      : bedrockUsage.totalTokens,
+				aiRequest        : arguments.aiRequest,
+				usage            : bedrockUsage.raw,
+				timestamp        : now()
+			} );
+		}
 
 		// Log completion
 		if ( arguments.aiRequest.getLogResponse() ) {
@@ -1196,10 +1226,43 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 				payloadJson = jsonDeserialize( decodedPayload );
 			}
 
+			// Capture usage data from various Bedrock model formats before transformation
+			var chunkUsage = {};
+			// Claude-on-Bedrock: message_start has input_tokens, message_delta has output_tokens
+			if( payloadJson.keyExists( "type" ) && payloadJson.type == "message_start" && !isNull( payloadJson.message?.usage ) ){
+				chunkUsage = {
+					"prompt_tokens"     : payloadJson.message.usage.input_tokens ?: 0,
+					"completion_tokens" : 0,
+					"total_tokens"      : payloadJson.message.usage.input_tokens ?: 0
+				};
+			}
+			if( payloadJson.keyExists( "type" ) && payloadJson.type == "message_delta" && !isNull( payloadJson.usage ) ){
+				chunkUsage = {
+					"prompt_tokens"     : 0,
+					"completion_tokens" : payloadJson.usage.output_tokens ?: 0,
+					"total_tokens"      : payloadJson.usage.output_tokens ?: 0
+				};
+			}
+			// Amazon invocation metrics (present in final event for all model families)
+			if( payloadJson.keyExists( "amazon-bedrock-invocationMetrics" ) ){
+				var metrics = payloadJson[ "amazon-bedrock-invocationMetrics" ];
+				chunkUsage = {
+					"prompt_tokens"     : metrics.inputTokenCount ?: 0,
+					"completion_tokens" : metrics.outputTokenCount ?: 0,
+					"total_tokens"      : ( metrics.inputTokenCount ?: 0 ) + ( metrics.outputTokenCount ?: 0 )
+				};
+			}
+
 			// Transform and send to callback
 			var streamChunk = transformStreamChunk( payloadJson, arguments.modelFamily, arguments.modelId );
 			if ( !isNull( streamChunk ) ) {
+				if( !structIsEmpty( chunkUsage ) ){
+					streamChunk.usage = chunkUsage;
+				}
 				arguments.callback( streamChunk );
+			} else if( !structIsEmpty( chunkUsage ) ){
+				// Send a usage-only chunk so the callback can capture it
+				arguments.callback( { "usage": chunkUsage, "choices": [], "model": arguments.modelId } );
 			}
 		} catch ( any e ) {
 			// Not valid JSON or processing error - may be a control message

--- a/src/main/bx/models/providers/ClaudeService.bx
+++ b/src/main/bx/models/providers/ClaudeService.bx
@@ -138,7 +138,8 @@ class extends="BaseService" implements="IAiChatService" {
 			"toolInputBuffers": {},
 			"toolCallIndexMap": {},
 			"stopReason": "",
-			"emittedAnyText": false
+			"emittedAnyText": false,
+			"usage": { "input_tokens": 0, "output_tokens": 0 }
 		};
 
 		var httpRequest = http( getChatURL() )
@@ -167,6 +168,9 @@ class extends="BaseService" implements="IAiChatService" {
 					if( parsedChunk.type == "message_start" ){
 						streamState.model = parsedChunk.message?.model ?: streamState.model;
 						streamState.messageId = parsedChunk.message?.id ?: streamState.messageId;
+						if( !isNull( parsedChunk.message?.usage ) ){
+							streamState.usage.input_tokens = parsedChunk.message.usage.input_tokens ?: 0;
+						}
 						return;
 					}
 
@@ -219,6 +223,9 @@ class extends="BaseService" implements="IAiChatService" {
 
 					if( parsedChunk.type == "message_delta" ){
 						streamState.stopReason = parsedChunk.delta?.stop_reason ?: streamState.stopReason;
+						if( !isNull( parsedChunk.usage ) ){
+							streamState.usage.output_tokens = parsedChunk.usage.output_tokens ?: 0;
+						}
 						return;
 					}
 				} catch( any e ){
@@ -271,6 +278,24 @@ class extends="BaseService" implements="IAiChatService" {
 				);
 			} )
 			.send();
+
+		// -------------------------------------------------------------------------------------------
+		// --- Usage Event Announcement (Streaming) ---
+		// -------------------------------------------------------------------------------------------
+		var claudeStreamTotalTokens = streamState.usage.input_tokens + streamState.usage.output_tokens;
+		if( claudeStreamTotalTokens > 0 ){
+			BoxAnnounce( "onAITokenCount", {
+				provider         : this,
+				operation        : "stream",
+				model            : arguments.chatRequest.getModel(),
+				promptTokens     : streamState.usage.input_tokens,
+				completionTokens : streamState.usage.output_tokens,
+				totalTokens      : claudeStreamTotalTokens,
+				aiRequest        : arguments.chatRequest,
+				usage            : streamState.usage,
+				timestamp        : now()
+			} )
+		}
 
 		if( streamState.stopReason == "tool_use" && streamState.toolCalls.len() ){
 			var runtimeChatRequest = arguments.chatRequest;

--- a/src/main/bx/models/providers/CohereService.bx
+++ b/src/main/bx/models/providers/CohereService.bx
@@ -353,6 +353,7 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 		var userCallback = arguments.callback;
 		var thisChatRequest = arguments.chatRequest;
 		var requestedModel = arguments.chatRequest.getModel();
+		var cohereUsage = { "inputTokens": 0, "outputTokens": 0, "totalTokens": 0, "raw": {} };
 		var emitNormalizedChunk = ( parsedChunk ) => {
 			var content = parsedChunk.text ?: ""
 			var finishReason = ""
@@ -497,6 +498,16 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 				// Try to parse and send to callback
 				try {
 					var parsedChunk = jsonDeserialize( chunk.data );
+
+					// Capture usage from stream-end event
+					if( ( parsedChunk.event_type ?: "" ) == "stream-end" && !isNull( parsedChunk.response?.meta?.billed_units ) ){
+						var billedUnits = parsedChunk.response.meta.billed_units;
+						cohereUsage.inputTokens  = billedUnits.input_tokens ?: 0;
+						cohereUsage.outputTokens = billedUnits.output_tokens ?: 0;
+						cohereUsage.totalTokens  = cohereUsage.inputTokens + cohereUsage.outputTokens;
+						cohereUsage.raw          = parsedChunk.response.meta;
+					}
+
 					emitNormalizedChunk( parsedChunk );
 				} catch( any e ){
 					writeLog(
@@ -550,6 +561,23 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService" 
 				);
 			} )
 			.send();
+
+		// -------------------------------------------------------------------------------------------
+		// --- Usage Event Announcement (Streaming) ---
+		// -------------------------------------------------------------------------------------------
+		if( cohereUsage.totalTokens > 0 ){
+			BoxAnnounce( "onAITokenCount", {
+				provider         : this,
+				operation        : "stream",
+				model            : arguments.chatRequest.getModel(),
+				promptTokens     : cohereUsage.inputTokens,
+				completionTokens : cohereUsage.outputTokens,
+				totalTokens      : cohereUsage.totalTokens,
+				aiRequest        : arguments.chatRequest,
+				usage            : cohereUsage.raw,
+				timestamp        : now()
+			} )
+		}
 	}
 
 	/**

--- a/src/main/bx/models/providers/GeminiService.bx
+++ b/src/main/bx/models/providers/GeminiService.bx
@@ -277,9 +277,18 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService, 
 
 		// No auth header for Gemini
 		arguments.chatRequest.setSendAuthHeader( false );
+		var geminiUsage = { "promptTokens": 0, "completionTokens": 0, "totalTokens": 0, "raw": {} };
 		var normalizedCallback = ( chunk ) => {
 			var content = chunk.candidates?.first()?.content?.parts?.first()?.text ?: "";
 			var finishReason = chunk.candidates?.first()?.finishReason ?: "";
+
+			// Capture usage metadata from Gemini chunks
+			if( !isNull( chunk.usageMetadata ) ){
+				geminiUsage.promptTokens     = chunk.usageMetadata.promptTokenCount ?: 0;
+				geminiUsage.completionTokens = chunk.usageMetadata.candidatesTokenCount ?: 0;
+				geminiUsage.totalTokens      = chunk.usageMetadata.totalTokenCount ?: 0;
+				geminiUsage.raw              = chunk.usageMetadata;
+			}
 
 			userCallback({
 				"provider": "Gemini",
@@ -301,6 +310,23 @@ class extends="OpenAIService" implements="IAiChatService, IAiEmbeddingsService, 
 
 		// Send it with streaming
 		sendStreamRequest( chatRequest, dataPacket, normalizedCallback )
+
+		// -------------------------------------------------------------------------------------------
+		// --- Usage Event Announcement (Streaming) ---
+		// -------------------------------------------------------------------------------------------
+		if( geminiUsage.totalTokens > 0 ){
+			BoxAnnounce( "onAITokenCount", {
+				provider         : this,
+				operation        : "stream",
+				model            : arguments.chatRequest.getModel(),
+				promptTokens     : geminiUsage.promptTokens,
+				completionTokens : geminiUsage.completionTokens,
+				totalTokens      : geminiUsage.totalTokens,
+				aiRequest        : arguments.chatRequest,
+				usage            : geminiUsage.raw,
+				timestamp        : now()
+			} )
+		}
 	}
 
 	/**

--- a/src/main/bx/models/providers/OpenAIService.bx
+++ b/src/main/bx/models/providers/OpenAIService.bx
@@ -386,6 +386,15 @@ class extends="BaseService" implements="IAiChatService, IAiEmbeddingsService, IA
 		}.append( arguments.chatRequest.getParams() )
 
 		// -------------------------------------------------------------------------------------------
+		// --- Request usage data in stream response ---
+		// -------------------------------------------------------------------------------------------
+		if( !dataPacket.keyExists( "stream_options" ) ){
+			dataPacket[ "stream_options" ] = { "include_usage": true };
+		} else if( isStruct( dataPacket.stream_options ) && !dataPacket.stream_options.keyExists( "include_usage" ) ){
+			dataPacket.stream_options[ "include_usage" ] = true;
+		}
+
+		// -------------------------------------------------------------------------------------------
 		// --- Tooling Detection ---
 		// -------------------------------------------------------------------------------------------
 		if( dataPacket.keyExists( "tools" ) ){
@@ -417,6 +426,26 @@ class extends="BaseService" implements="IAiChatService, IAiEmbeddingsService, IA
 		// --- Fire local callback for post mods ---
 		// -------------------------------------------------------------------------------------------
 		streamState = postResponse( arguments.chatRequest, dataPacket, streamState, "stream" )
+
+		// -------------------------------------------------------------------------------------------
+		// --- Usage Event Announcement (Streaming) ---
+		// -------------------------------------------------------------------------------------------
+		if( !structIsEmpty( streamState.usage ) ){
+			var streamTotalTokens = streamState.usage.keyExists( "total_tokens" ) ? streamState.usage.total_tokens : 0;
+			if( streamTotalTokens > 0 ){
+				BoxAnnounce( "onAITokenCount", {
+					provider         : this,
+					operation        : "stream",
+					model            : arguments.chatRequest.getModel(),
+					promptTokens     : streamState.usage.keyExists( "prompt_tokens" )     ? streamState.usage.prompt_tokens     : 0,
+					completionTokens : streamState.usage.keyExists( "completion_tokens" ) ? streamState.usage.completion_tokens : 0,
+					totalTokens      : streamTotalTokens,
+					aiRequest        : arguments.chatRequest,
+					usage            : streamState.usage,
+					timestamp        : now()
+				} )
+			}
+		}
 
 		// -------------------------------------------------------------------------------------------
 		// --- Fire afterLLMCall middleware, in reverse order ---


### PR DESCRIPTION
# Description

`chatStream()` across all providers never fires the `onAITokenCount` event, making streaming calls completely invisible to usage tracking, billing, and monitoring. The non-streaming `chat()` path fires it correctly.

Three root causes were identified and fixed:

1. **`updateStreamState()` in BaseService discards usage data** — The final SSE chunk from OpenAI-compatible providers contains usage data but has empty `choices`. The method returned early before checking for usage.
2. **No provider fires `onAITokenCount` after streaming** — None of the six provider families had event-firing code in their streaming paths.
3. **OpenAI-compatible providers don't request usage data** — `stream_options: { include_usage: true }` was not being sent, so OpenAI never included usage in the stream.

### Changes by file

| File | Change |
|------|--------|
| `BaseService.bx` | Add `usage` to `streamState`; capture usage in `updateStreamState()` before early return on empty choices |
| `OpenAIService.bx` | Auto-add `stream_options.include_usage`; fire `onAITokenCount` after stream completes. Covers all OpenAI-compatible subclasses (Groq, Grok, DeepSeek, Mistral, HuggingFace, MiniMax, Perplexity, OpenRouter, Ollama, DockerModelRunner) |
| `ClaudeService.bx` | Capture `input_tokens` from `message_start` and `output_tokens` from `message_delta`; fire event after `.send()` |
| `GeminiService.bx` | Capture `usageMetadata` from chunks; fire event after `sendStreamRequest()` |
| `BedrockService.bx` | Extract usage from Claude SSE events and `amazon-bedrock-invocationMetrics`; wrap callback to accumulate; fire event after stream parsing |
| `CohereService.bx` | Capture `billed_units` from `stream-end` event; fire event after `.send()` |

All providers fire a consistent event structure with `operation: "stream"` and a `totalTokens > 0` guard.

## Jira/Github Issues

Closes https://github.com/ortus-boxlang/bx-ai/issues/171

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
