### PR TITLE
feat: add pause/resume functionality to MCPServer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🥊 New Features
+
+- **MCP Server Pause/Resume**: `MCPServer` now supports pausing and resuming via `pause()` and `resume()` fluent methods. While paused, the server remains registered in the global registry but rejects all incoming JSON-RPC requests (except `ping`) with a `SERVER_PAUSED` error (code `-32005`). This lets an admin interface or AI service temporarily halt a server without destroying its configuration, tools, resources, or prompts. Resume restores normal request handling instantly.
+  - `pause()` — pause the server; fires `onMCPServerPause` interception point.
+  - `resume()` — resume the server; fires `onMCPServerResume` interception point.
+  - `isPaused()` — returns `true` if currently paused.
+  - `getSummary()` now includes a `paused` boolean field.
+  - New `SERVER_PAUSED: -32005` error code added to `RPC_ERROR_CODES`.
+  - Two new interception points registered: `onMCPServerPause`, `onMCPServerResume`.
+
 ## [3.1.0] - 2026-04-16
 
 ### 🥊 New Features

--- a/src/main/bx/ModuleConfig.bx
+++ b/src/main/bx/ModuleConfig.bx
@@ -253,7 +253,9 @@ class {
 
 			// MCP Server Events
 			"onMCPServerCreate",
+			"onMCPServerPause",
 			"onMCPServerRemove",
+			"onMCPServerResume",
 			"onMCPRequest",
 			"onMCPResponse",
 			"onMCPError",

--- a/src/main/bx/models/mcp/MCPServer.bx
+++ b/src/main/bx/models/mcp/MCPServer.bx
@@ -109,6 +109,12 @@ class {
 	property name="apiKeyProvider" type="any" default="";
 
 	/**
+	 * Whether this server is currently paused.
+	 * When paused, all requests except "ping" are rejected with a SERVER_PAUSED error.
+	 */
+	property name="paused" type="boolean" default=false;
+
+	/**
 	 * Static configuration and service reference
 	 */
 	static {
@@ -129,6 +135,7 @@ class {
 			RATE_LIMIT_EXCEEDED: -32002,
 			SERVER_ERROR: -32000,
 			SERVER_OVERLOAD: -32001,
+			SERVER_PAUSED: -32005,
 			SESSION_EXPIRED: -32003,
 			TIMEOUT_ERROR: -32070,
 			TRANSPORT_ERROR: -32060
@@ -170,6 +177,7 @@ class {
 		variables.basicAuthPassword = ""
 		variables.maxRequestBodySize = 0
 		variables.apiKeyProvider = ""
+		variables.paused = false
 
 		return this
 	}
@@ -1030,6 +1038,7 @@ class {
 	struct function getSummary() {
 		return {
 			"description": variables.description,
+			"paused": variables.paused,
 			"promptCount": variables.prompts.count(),
 			"prompts": listPrompts(),
 			"resourceCount": variables.resources.count(),
@@ -1039,6 +1048,44 @@ class {
 			"tools": listTools(),
 			"version": variables.version
 		}
+	}
+
+	/**
+	 * Pause this MCP server. While paused, all requests except "ping" are rejected
+	 * with a SERVER_PAUSED error. The server remains registered and can be resumed.
+	 *
+	 * @return This instance for fluent method chaining
+	 */
+	MCPServer function pause() {
+		if ( !variables.paused ) {
+			variables.paused = true
+			static.mcpLogger.info( "MCP server paused: #variables.serverName#" )
+			BoxAnnounce( "onMCPServerPause", { server: this, name: variables.serverName } )
+		}
+		return this
+	}
+
+	/**
+	 * Resume this MCP server. Requests will be processed normally after resuming.
+	 *
+	 * @return This instance for fluent method chaining
+	 */
+	MCPServer function resume() {
+		if ( variables.paused ) {
+			variables.paused = false
+			static.mcpLogger.info( "MCP server resumed: #variables.serverName#" )
+			BoxAnnounce( "onMCPServerResume", { server: this, name: variables.serverName } )
+		}
+		return this
+	}
+
+	/**
+	 * Check if this server is currently paused
+	 *
+	 * @return Boolean true if paused, false if active
+	 */
+	boolean function isPaused() {
+		return variables.paused
 	}
 
 	/**
@@ -1300,6 +1347,15 @@ class {
 		var requestId = thisRequest?.id ?: ""
 		var method = thisRequest.method ?: ""
 		var params = thisRequest.params ?: {}
+
+		// Reject all non-ping requests while paused
+		if ( variables.paused && method.trim() != "ping" ) {
+			return buildErrorResponse(
+				requestId,
+				static.RPC_ERROR_CODES.SERVER_PAUSED,
+				"Server '#variables.serverName#' is paused and not accepting requests"
+			)
+		}
 
 		try {
 			var result = {}

--- a/src/test/java/ortus/boxlang/ai/mcp/mcpServerTest.java
+++ b/src/test/java/ortus/boxlang/ai/mcp/mcpServerTest.java
@@ -1739,4 +1739,183 @@ public class mcpServerTest extends BaseIntegrationTest {
 		assertThat( variables.get( Key.of( "hasPrompt" ) ) ).isEqualTo( true );
 	}
 
+	@Test
+	@DisplayName( "Server is not paused by default" )
+	public void testNotPausedByDefault() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "pauseDefaultTest" )
+				isPaused = myServer.isPaused()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "isPaused" ) ) ).isEqualTo( false );
+	}
+
+	@Test
+	@DisplayName( "pause() sets isPaused to true" )
+	public void testPauseSetsPausedState() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "pauseStateTest" )
+				myServer.pause()
+				isPaused = myServer.isPaused()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "isPaused" ) ) ).isEqualTo( true );
+	}
+
+	@Test
+	@DisplayName( "resume() clears paused state" )
+	public void testResumeClears() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "resumeTest" )
+				myServer.pause()
+				afterPause = myServer.isPaused()
+				myServer.resume()
+				afterResume = myServer.isPaused()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "afterPause" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "afterResume" ) ) ).isEqualTo( false );
+	}
+
+	@Test
+	@DisplayName( "handleRequest returns SERVER_PAUSED error when paused" )
+	public void testHandleRequestWhenPaused() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "pausedRequestTest" )
+					.registerTool( aiTool( "test", "Test tool", ( x ) => "ok" ) )
+					.pause()
+
+				response = myServer.handleRequest( {
+					"jsonrpc": "2.0",
+					"method": "tools/list",
+					"id": "1"
+				} )
+
+				hasError = structKeyExists( response, "error" )
+				errorCode = response.error.code
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "hasError" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "errorCode" ) ) ).isEqualTo( -32005 );
+	}
+
+	@Test
+	@DisplayName( "ping succeeds even when server is paused" )
+	public void testPingSucceedsWhenPaused() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "pausedPingTest" ).pause()
+
+				response = myServer.handleRequest( {
+					"jsonrpc": "2.0",
+					"method": "ping",
+					"id": "hb-1"
+				} )
+
+				hasResult = structKeyExists( response, "result" )
+				hasError  = structKeyExists( response, "error" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "hasResult" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "hasError" ) ) ).isEqualTo( false );
+	}
+
+	@Test
+	@DisplayName( "getSummary includes paused field" )
+	public void testGetSummaryIncludesPaused() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "summaryPausedTest" )
+				summaryBefore    = myServer.getSummary()
+				hasPausedBefore  = structKeyExists( summaryBefore, "paused" )
+				pausedBefore     = summaryBefore.paused
+
+				myServer.pause()
+				summaryAfter = myServer.getSummary()
+				pausedAfter  = summaryAfter.paused
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "hasPausedBefore" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "pausedBefore" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "pausedAfter" ) ) ).isEqualTo( true );
+	}
+
+	@Test
+	@DisplayName( "pause() and resume() support fluent chaining" )
+	public void testPauseResumeChaining() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "pauseChainTest" )
+					.pause()
+					.resume()
+					.registerTool( aiTool( "t", "T", ( x ) => x ) )
+
+				isObject  = isObject( myServer )
+				isPaused  = myServer.isPaused()
+				toolCount = myServer.getToolCount()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "isObject" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "isPaused" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "toolCount" ) ) ).isEqualTo( 1 );
+	}
+
+	@Test
+	@DisplayName( "After resume, requests are processed normally" )
+	public void testRequestsProcessedAfterResume() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				myServer = mcpServer( "resumeRequestTest" )
+					.registerTool( aiTool( "echo", "Echo", ( msg ) => "Echo: " & msg ) )
+					.pause()
+					.resume()
+
+				response  = myServer.handleRequest( {
+					"jsonrpc": "2.0",
+					"method": "tools/list",
+					"id": "1"
+				} )
+
+				hasResult = structKeyExists( response, "result" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "hasResult" ) ) ).isEqualTo( true );
+	}
+
 }


### PR DESCRIPTION
- New `pause()` / `resume()` fluent methods with idempotency guards
- New `isPaused()` boolean accessor
- `handleRequest()` rejects all non-ping requests with error code -32005
  (SERVER_PAUSED) while paused; ping remains available for health checks
- `getSummary()` now includes the `paused` field
- `onMCPServerPause` and `onMCPServerResume` BoxAnnounce events registered
  in ModuleConfig.bx
- 7 new tests covering default state, pause/resume lifecycle, error response,
  ping exemption, summary field, chaining, and post-resume service restoration

https://claude.ai/code/session_019M5Pz9111cWuZj9oQ4Kby6