### PR TITLE
Add AIAgentRegistry for agent observability and analytics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🥊 New Features
 
+- **Agent Registry** — New `AIAgentRegistry` singleton (access via `aiAgentRegistry()` BIF) modeled after `AIToolRegistry`. Allows users to explicitly register `AiAgent` instances for centralized discoverability, observability, and analytics.
+  - `aiAgentRegistry().register( agent, module )` — register an `AiAgent` instance with optional module namespace. Key convention: `agentName` or `agentName@moduleName`.
+  - `aiAgentRegistry().unregister( key )` / `unregisterByModule( module )` — remove agents from the registry.
+  - `aiAgentRegistry().resolveAgents( array )` — lazily resolve a mixed array of string keys and `AiAgent` instances into `AiAgent[]`.
+  - `aiAgentRegistry().listAgents()` — returns a struct of all registered agents mapped to `{ name, description, module }` for analytics dashboards and introspection.
+  - `aiAgentRegistry().getAgentInfo( key )` — returns `{ name, description, module }` for a single registry key.
+  - Two new interception points: `onAIAgentRegistryRegister`, `onAIAgentRegistryUnregister` — fired on every register/unregister operation for external observability hooks.
+  - `aiAgent()` BIF gains two new parameters: `register: false` (opt-in flag) and `module: ""` — when `register: true` the agent is automatically placed in the registry at creation time. Defaults to `false` to prevent memory leaks from sub-agents and throwaway agents.
+
 - **MCP Server Pause/Resume**: `MCPServer` now supports pausing and resuming via `pause()` and `resume()` fluent methods. While paused, the server remains registered in the global registry but rejects all incoming JSON-RPC requests (except `ping`) with a `SERVER_PAUSED` error (code `-32005`). This lets an admin interface or AI service temporarily halt a server without destroying its configuration, tools, resources, or prompts. Resume restores normal request handling instantly.
   - `pause()` — pause the server; fires `onMCPServerPause` interception point.
   - `resume()` — resume the server; fires `onMCPServerResume` interception point.

--- a/src/main/bx/ModuleConfig.bx
+++ b/src/main/bx/ModuleConfig.bx
@@ -262,7 +262,11 @@ class {
 
 			// Tool Registry Events
 			"onAIToolRegistryRegister",
-			"onAIToolRegistryUnregister"
+			"onAIToolRegistryUnregister",
+
+			// Agent Registry Events
+			"onAIAgentRegistryRegister",
+			"onAIAgentRegistryUnregister"
 		 ]
 	}
 

--- a/src/main/bx/bifs/aiAgent.bx
+++ b/src/main/bx/bifs/aiAgent.bx
@@ -43,6 +43,8 @@ class {
 	 * @checkpointer IAiMemory instance used to save/load checkpoint state for suspend-resume
 	 * @checkpointTTL Time-to-live for checkpoint state in minutes (0 = no expiry)
 	 * @mcpServers Array of MCP server URLs to seed into the agent for internal tool calls to sub-agents and tools
+	 * @register When true, registers the agent in the aiAgentRegistry() singleton for observability and analytics. Defaults to false to avoid memory leaks from throwaway or sub-agents.
+	 * @module Module namespace used as the registry key suffix when register is true (e.g. "my-module" → "AgentName@my-module")
 	 *
 	 * @return AiAgent instance for fluent chaining
 	 */
@@ -61,7 +63,9 @@ class {
 		any middleware      = [],
 		any checkpointer,
 		numeric checkpointTTL = 30,
-		array mcpServers    = []
+		array mcpServers    = [],
+		boolean register    = false,
+		string module       = ""
 	) {
 		if( isSimpleValue( arguments.skills ) ){
 			arguments.skills = [ arguments.skills ]
@@ -83,6 +87,11 @@ class {
 
 		// Announce agent creation for observability and extensibility (e.g. logging, analytics, etc.)
 		BoxAnnounce( "onAIAgentCreate", { agent: agent } )
+
+		// Opt-in registration in the agent registry for observability and analytics
+		if ( arguments.register ) {
+			aiAgentRegistry().register( agent, arguments.module )
+		}
 
 		return agent
 	}

--- a/src/main/bx/bifs/aiAgentRegistry.bx
+++ b/src/main/bx/bifs/aiAgentRegistry.bx
@@ -1,0 +1,36 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * ----------------------------------------------------------------------------------
+ * Returns the singleton AIAgentRegistry instance.
+ *
+ * Usage:
+ *   aiAgentRegistry().register( agent )
+ *   aiAgentRegistry().register( agent, "my-module" )
+ *   aiAgentRegistry().get( "MyAgent@my-module" )
+ *   aiAgentRegistry().has( "MyAgent" )
+ *   aiAgentRegistry().listAgents()
+ */
+import bxModules.bxai.models.registry.AIAgentRegistry;
+
+@BoxBIF
+class {
+
+	// Create the singleton registry instance on class load
+	variables.registry = new AIAgentRegistry()
+
+	function invoke() {
+		return variables.registry
+	}
+
+}

--- a/src/main/bx/models/registry/AIAgentRegistry.bx
+++ b/src/main/bx/models/registry/AIAgentRegistry.bx
@@ -1,0 +1,150 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * ----------------------------------------------------------------------------------
+ * Singleton registry for AI Agents.
+ *
+ * Access via aiAgentRegistry() BIF
+ *
+ * Key convention: agentName or agentName@moduleName
+ *
+ * Registration:
+ *   aiAgentRegistry().register( agent )
+ *   aiAgentRegistry().register( agent, "my-module" )
+ *
+ * Lazy resolution:
+ *   aiAgentRegistry().resolveAgents( [ "MyAgent@my-module", agentInstance ] )
+ *   Converts string keys to AiAgent instances.
+ *
+ * Observability:
+ *   aiAgentRegistry().listAgents()       — all agents with name/description/module
+ *   aiAgentRegistry().getAgentInfo( key ) — info for a specific agent
+ */
+import bxModules.bxai.models.runnables.AiAgent;
+
+class extends="BaseRegistry" {
+
+	// -------------------------------------------------------------------------
+	// Registry Methods
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Register an AiAgent instance in the registry.
+	 *
+	 * @agent  The AiAgent instance to register
+	 * @module Module name for namespacing (optional)
+	 *
+	 * @throws InvalidArgument if the item is not an AiAgent instance
+	 */
+	AIAgentRegistry function register( required any agent, string module = "" ) {
+		if ( isNull( arguments.agent ) || !( arguments.agent instanceof "AiAgent" ) ) {
+			throw(
+				type    : "InvalidArgument",
+				message : "register() requires an AiAgent instance."
+			)
+		}
+
+		super.register( arguments.agent.getAgentName(), arguments.agent, arguments.module )
+		BoxAnnounce( "onAIAgentRegistryRegister", {
+			agent  : arguments.agent,
+			key    : buildKey( arguments.agent.getAgentName(), arguments.module ),
+			module : arguments.module
+		} )
+		return this
+	}
+
+	/**
+	 * Unregister by exact key and fire the onAIAgentRegistryUnregister event.
+	 *
+	 * @key The exact registry key to remove
+	 *
+	 * @returns The registry instance for chaining
+	 */
+	AIAgentRegistry function unregister( required string key ) {
+		super.unregister( arguments.key )
+		BoxAnnounce( "onAIAgentRegistryUnregister", {
+			key    : arguments.key,
+			module : extractModule( arguments.key )
+		} )
+		return this
+	}
+
+	/**
+	 * Unregister all agents registered under a specific module and fire per-item events.
+	 *
+	 * @module The module name whose agents should be removed
+	 */
+	AIAgentRegistry function unregisterByModule( required string module ) {
+		getKeys()
+			.filter( key => extractModule( key ) == module )
+			.each( key => unregister( key ) )
+		return this
+	}
+
+	/**
+	 * Resolve a mixed array of AiAgent instances and/or string registry keys into AiAgent[].
+	 * Called to lazily resolve string keys to agent instances.
+	 *
+	 * @agents Array of AiAgent instances or string registry keys
+	 * @throws RegistryItemNotFoundException if a string key cannot be resolved
+	 *
+	 * @return Array of AiAgent instances
+	 */
+	array function resolveAgents( required array agents ) {
+		return arguments.agents.map( agent => {
+			return isSimpleValue( arguments.agent ) ?
+				this.get( arguments.agent ) :
+				arguments.agent
+		} )
+	}
+
+	/**
+	 * Get agent info (name and description) for a given registry key, without returning the full AiAgent instance.
+	 *
+	 * @key The registry key of the agent (e.g. "MyAgent@my-module")
+	 * @throws RegistryItemNotFoundException if the key cannot be found
+	 *
+	 * @return Struct with 'name', 'description', and 'module' of the agent
+	 */
+	struct function getAgentInfo( required string key ) {
+		var agent = this.get( arguments.key )
+		if ( isNull( agent ) ) {
+			throw(
+				type    : "RegistryItemNotFoundException",
+				message : "No agent found for key: " & arguments.key
+			)
+		}
+		return {
+			name        : agent.getAgentName(),
+			description : agent.getDescription(),
+			module      : extractModule( arguments.key )
+		}
+	}
+
+	/**
+	 * List all registered agents with their keys, names, and descriptions.
+	 * This is the primary analytics/observability surface for the registry.
+	 *
+	 * @return Struct of all registered agents, keyed by registry key, with name, description, and module.
+	 */
+	struct function listAgents() {
+		return variables.registry.map( ( key, agent ) => {
+			return {
+				name        : agent.getAgentName(),
+				description : agent.getDescription(),
+				module      : extractModule( key )
+			}
+		} )
+	}
+
+}

--- a/src/test/java/ortus/boxlang/ai/registry/AiAgentRegistryTest.java
+++ b/src/test/java/ortus/boxlang/ai/registry/AiAgentRegistryTest.java
@@ -1,0 +1,354 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.ai.registry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.ai.BaseIntegrationTest;
+import ortus.boxlang.runtime.scopes.Key;
+
+public class AiAgentRegistryTest extends BaseIntegrationTest {
+
+	// -------------------------------------------------------------------------
+	// Registration
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "register() stores an AiAgent instance and has() returns true" )
+	@Test
+	public void testRegisterStoresAgent() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "TestRegisterAgent", description: "Test agent" )
+				reg.register( agent )
+				result = reg.has( "TestRegisterAgent" )
+				// Cleanup
+				reg.unregister( "TestRegisterAgent" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+	@DisplayName( "register() with module creates a namespaced key" )
+	@Test
+	public void testRegisterWithModuleNamespacesKey() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "NsAgent", description: "Namespaced agent" )
+				reg.register( agent, "test-mod" )
+				result     = reg.has( "NsAgent@test-mod" )
+				resultBare = reg.has( "NsAgent" )
+				// Cleanup
+				reg.unregisterByModule( "test-mod" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "resultBare" ) ) ).isEqualTo( true );
+	}
+
+	@DisplayName( "register() without a valid AiAgent throws InvalidArgument" )
+	@Test
+	public void testRegisterInvalidArgThrows() {
+		try {
+			// @formatter:off
+			runtime.executeSource(
+				"""
+					aiAgentRegistry().register( "notAnAgent" )
+				""",
+				context
+			);
+			// @formatter:on
+			fail( "Expected exception was not thrown" );
+		} catch ( Exception e ) {
+			assertThat( e.getMessage() ).contains( "requires an AiAgent instance" );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Retrieval
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "get() by exact key returns the registered agent" )
+	@Test
+	public void testGetByExactKey() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "ExactGetAgent", description: "Exact get test" )
+				reg.register( agent )
+				fetched = reg.get( "ExactGetAgent" )
+				result  = fetched.getAgentName()
+				// Cleanup
+				reg.unregister( "ExactGetAgent" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "ExactGetAgent" );
+	}
+
+	@DisplayName( "get() by bare name resolves a namespaced agent via partial match" )
+	@Test
+	public void testGetByBareNameResolvesNamespaced() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "PartialAgent", description: "Partial match" )
+				reg.register( agent, "test-partial" )
+				fetched = reg.get( "PartialAgent" )
+				result  = fetched.getAgentName()
+				// Cleanup
+				reg.unregisterByModule( "test-partial" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "PartialAgent" );
+	}
+
+	@DisplayName( "has() returns false for unregistered keys" )
+	@Test
+	public void testHasReturnsFalseForMissing() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				result = aiAgentRegistry().has( "totallyMissingAgent_xyz" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( false );
+	}
+
+	// -------------------------------------------------------------------------
+	// Module-scoped operations
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "unregisterByModule() removes all agents registered under that module" )
+	@Test
+	public void testUnregisterByModuleRemovesAllAgents() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg    = aiAgentRegistry()
+				agent1 = aiAgent( name: "ModAgent1", description: "First" )
+				agent2 = aiAgent( name: "ModAgent2", description: "Second" )
+				reg.register( agent1, "test-cleanup" )
+				reg.register( agent2, "test-cleanup" )
+				reg.unregisterByModule( "test-cleanup" )
+				result1 = reg.has( "ModAgent1@test-cleanup" )
+				result2 = reg.has( "ModAgent2@test-cleanup" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "result1" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( false );
+	}
+
+	@DisplayName( "getByModule() returns only agents registered under that module" )
+	@Test
+	public void testGetByModuleFiltersCorrectly() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg    = aiAgentRegistry()
+				agent1 = aiAgent( name: "ByModA", description: "A" )
+				agent2 = aiAgent( name: "ByModB", description: "B" )
+				reg.register( agent1, "test-bymod" )
+				reg.register( agent2, "test-bymod" )
+				agents = reg.getByModule( "test-bymod" )
+				result = agents.len()
+				// Cleanup
+				reg.unregisterByModule( "test-bymod" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( ( Integer ) variables.getAsInteger( result ) ).isAtLeast( 2 );
+	}
+
+	// -------------------------------------------------------------------------
+	// resolveAgents()
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "resolveAgents() converts string keys to AiAgent instances" )
+	@Test
+	public void testResolveAgentsConvertsStrings() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "ResolveAgent", description: "Resolve test" )
+				reg.register( agent )
+				resolved = reg.resolveAgents( [ "ResolveAgent" ] )
+				result   = resolved[ 1 ].getAgentName()
+				// Cleanup
+				reg.unregister( "ResolveAgent" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "ResolveAgent" );
+	}
+
+	@DisplayName( "resolveAgents() passes through existing AiAgent instances unchanged" )
+	@Test
+	public void testResolveAgentsPassesThroughInstances() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				agent    = aiAgent( name: "PassThroughAgent", description: "Pass-through" )
+				resolved = aiAgentRegistry().resolveAgents( [ agent ] )
+				result   = ( resolved[ 1 ] === agent )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+	// -------------------------------------------------------------------------
+	// Observability / Analytics
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "listAgents() returns a struct with name, description, and module for each agent" )
+	@Test
+	public void testListAgentsReturnsInfo() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "ListAgent", description: "Listed agent" )
+				reg.register( agent, "test-list" )
+				listing = reg.listAgents()
+				info    = listing[ "ListAgent@test-list" ]
+				result  = ( info.name == "ListAgent" && info.description == "Listed agent" && info.module == "test-list" )
+				// Cleanup
+				reg.unregisterByModule( "test-list" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+	@DisplayName( "getAgentInfo() returns name, description, and module for a registry key" )
+	@Test
+	public void testGetAgentInfoReturnsStruct() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiAgentRegistry()
+				agent = aiAgent( name: "InfoAgent", description: "Info test agent" )
+				reg.register( agent, "test-info" )
+				info   = reg.getAgentInfo( "InfoAgent@test-info" )
+				result = ( info.name == "InfoAgent" && info.description == "Info test agent" && info.module == "test-info" )
+				// Cleanup
+				reg.unregisterByModule( "test-info" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+	// -------------------------------------------------------------------------
+	// Auto-registration via aiAgent() BIF flag
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "aiAgent( register: true ) automatically registers the agent in the registry" )
+	@Test
+	public void testAiAgentBifAutoRegister() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				agent  = aiAgent( name: "AutoRegistered", description: "Auto-reg agent", register: true, module: "test-auto" )
+				result = aiAgentRegistry().has( "AutoRegistered@test-auto" )
+				// Cleanup
+				aiAgentRegistry().unregisterByModule( "test-auto" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+	@DisplayName( "aiAgent( register: false ) does not register the agent (default)" )
+	@Test
+	public void testAiAgentBifNoAutoRegisterByDefault() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				agent  = aiAgent( name: "NotAutoRegistered_xyz", description: "Not registered" )
+				result = aiAgentRegistry().has( "NotAutoRegistered_xyz" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( false );
+	}
+
+	// -------------------------------------------------------------------------
+	// Singleton
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "aiAgentRegistry() returns the same singleton instance on repeated calls" )
+	@Test
+	public void testGetInstanceIsSingleton() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				r1     = aiAgentRegistry()
+				r2     = aiAgentRegistry()
+				result = ( r1 === r2 )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+}


### PR DESCRIPTION
Introduces a singleton agent registry modeled after AIToolRegistry,
allowing users to explicitly register AiAgent instances for
discoverability, observability, and analytics.

- AIAgentRegistry.bx: extends BaseRegistry; stores agents by
  agentName@module key; fires onAIAgentRegistryRegister /
  onAIAgentRegistryUnregister events; exposes listAgents() and
  getAgentInfo() as observability surfaces
- aiAgentRegistry.bx: @BoxBIF singleton accessor
- aiAgent.bx: adds register/module params (default register=false)
  for opt-in auto-registration, preventing memory leaks from
  throwaway/sub-agents
- ModuleConfig.bx: registers onAIAgentRegistryRegister and
  onAIAgentRegistryUnregister interception points
- AiAgentRegistryTest.java: full JUnit 5 coverage for registration,
  retrieval, module ops, resolveAgents, listAgents, BIF flag, singleton

https://claude.ai/code/session_01G83j23L27dzKRx5ug12tta