### PR TITLE
fix(tools): coerce struct/array args to JSON for string-typed params …

### DIFF
--- a/src/main/bx/models/tools/ClosureTool.bx
+++ b/src/main/bx/models/tools/ClosureTool.bx
@@ -78,6 +78,19 @@ class extends="BaseTool" {
 				message : "No callable has been set on this ClosureTool. Use call() before invoking."
 			)
 		}
+		// Coerce structured values to JSON strings for string-typed params. MCP clients may send
+		// object/array payloads for params whose schema declares "string" (e.g. JSON-encoded fields
+		// like source_context or key_decisions); without this, BoxLang's typed-arg binding would
+		// throw "Can't cast Struct<Ordered> to a string" before the callable runs.
+		var incomingArgs = arguments.args
+		variables.callable.$bx.meta.parameters.each( param => {
+			if ( ( param.type ?: "" ) == "string" && incomingArgs.keyExists( param.name ) ) {
+				var value = incomingArgs[ param.name ]
+				if ( !isNull( value ) && !isSimpleValue( value ) ) {
+					incomingArgs[ param.name ] = jsonSerialize( value )
+				}
+			}
+		} )
 		// Inject _chatRequest into args for closures that want conversation context
 		arguments.args._chatRequest = arguments.chatRequest
 		return variables.callable( argumentCollection = arguments.args )

--- a/src/test/java/ortus/boxlang/ai/tools/ClosureToolTest.java
+++ b/src/test/java/ortus/boxlang/ai/tools/ClosureToolTest.java
@@ -110,6 +110,77 @@ public class ClosureToolTest extends BaseIntegrationTest {
 		assertThat( variables.get( Key.of( "isString" ) ) ).isEqualTo( true );
 	}
 
+	@DisplayName( "invoke() coerces a struct arg to a JSON string for a string-typed param" )
+	@Test
+	public void testInvokeCoercesStructToJsonStringForStringParam() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.tools.ClosureTool;
+				tool = new ClosureTool(
+					"jsonTool",
+					"Accepts a JSON-encoded struct",
+					( required string source_context ) => arguments.source_context
+				)
+				result = tool.invoke( { source_context: { repo: "acme/app", branch: "main" } } )
+				parsed = jsonDeserialize( result )
+				repoOut   = parsed.repo
+				branchOut = parsed.branch
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "repoOut" ) ) ).isEqualTo( "acme/app" );
+		assertThat( variables.get( Key.of( "branchOut" ) ) ).isEqualTo( "main" );
+	}
+
+	@DisplayName( "invoke() coerces an array arg to a JSON string for a string-typed param" )
+	@Test
+	public void testInvokeCoercesArrayToJsonStringForStringParam() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.tools.ClosureTool;
+				tool = new ClosureTool(
+					"listTool",
+					"Accepts a JSON-encoded array",
+					( required string files_modified ) => arguments.files_modified
+				)
+				result = tool.invoke( { files_modified: [ "a.bx", "b.bx" ] } )
+				parsed = jsonDeserialize( result )
+				firstOut  = parsed[ 1 ]
+				lengthOut = parsed.len()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "firstOut" ) ) ).isEqualTo( "a.bx" );
+		assertThat( variables.get( Key.of( "lengthOut" ) ) ).isEqualTo( 2 );
+	}
+
+	@DisplayName( "invoke() leaves already-stringified args unchanged for string-typed params" )
+	@Test
+	public void testInvokeLeavesStringArgUnchanged() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.tools.ClosureTool;
+				tool = new ClosureTool(
+					"echoTool",
+					"Echoes its input",
+					( required string payload ) => arguments.payload
+				)
+				result = tool.invoke( { payload: '{"already":"json"}' } )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "{\"already\":\"json\"}" );
+	}
+
 	@DisplayName( "invoke() without a callable throws MissingCallable" )
 	@Test
 	public void testInvokeWithNoCallableThrows() {


### PR DESCRIPTION
# Description

`ClosureTool.doInvoke()` currently passes `arguments.args` straight into the callable via `argumentCollection`. When an MCP client sends a JSON-typed field (e.g. `source_context`, `key_decisions`, `files_modified`) as an actual JSON object or array — which several popular clients and SDKs do — BoxLang's typed-arg binding rejects the `Struct<Ordered>` / `Array` value against the declared `string` parameter and throws `Can't cast Struct<Ordered> to a string` before the callable body runs. Every affected tool call 500s with no opportunity for the callable to handle the payload.

This patch walks the callable's declared parameters and, for any parameter whose declared type is `string` and whose incoming value is non-simple, `jsonSerialize()` the value before delegating. The callable then deserializes as it already would (`jsonDeserialize( source_context )`) with no change, and string args remain untouched.

The generated MCP schema declares every parameter as `"type": "string"`, so the runtime now consistently accepts both supported wire formats (stringified JSON and raw JSON objects/arrays). Callables that explicitly declare `struct` / `array` / `any` params are unaffected — coercion only runs when the declared type is `string`.

## Jira/Github Issues

Module Issues: https://github.com/ortus-boxlang/bx-ai/issues/176

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes