### PR TITLE
fix(test): resolve aiImage test failures from merge

### DIFF
--- a/src/main/bx/models/requests/AiImageRequest.bx
+++ b/src/main/bx/models/requests/AiImageRequest.bx
@@ -39,19 +39,6 @@
  */
 class extends="AiBaseRequest" {
 
-	static {
-		POPULAR_SIZES = {
-			auto        : "auto",
-			square      : "1024x1024",
-			landscape   : "1536x1024",
-			portrait    : "1024x1536",
-			twoKsquare  : "2048x2048",
-			twoKlandscape : "2048x1152",
-			fourKlandscape: "3840x2160",
-			fourKportrait : "2160x3840"
-		}
-	}
-
 	/**
 	 * The text prompt describing the image to generate
 	 */
@@ -97,6 +84,19 @@ class extends="AiBaseRequest" {
 	 * Requested output image format (provider-specific): png, jpeg, or webp
 	 */
 	property name="format" default="png";
+
+	static {
+		POPULAR_SIZES = {
+			auto        : "auto",
+			square      : "1024x1024",
+			landscape   : "1536x1024",
+			portrait    : "1024x1536",
+			twoKsquare  : "2048x2048",
+			twoKlandscape : "2048x1152",
+			fourKlandscape: "3840x2160",
+			fourKportrait : "2160x3840"
+		}
+	}
 
 	/**
 	 * Constructor

--- a/src/test/java/ortus/boxlang/ai/bifs/aiImageTest.java
+++ b/src/test/java/ortus/boxlang/ai/bifs/aiImageTest.java
@@ -57,7 +57,7 @@ public class aiImageTest extends BaseIntegrationTest {
 		// @formatter:off
 		runtime.executeSource(
 			"""
-			toolExists = aiToolRegistry().get( "generateImage@bxai" ).isPresent()
+			toolExists = aiToolRegistry().has( "generateImage@bxai" )
 			""",
 			context
 		);
@@ -160,7 +160,7 @@ public class aiImageTest extends BaseIntegrationTest {
 		executeWithTimeoutHandling(
 			"""
 			response   = aiImage(
-				"a simple blue square on a white background",
+				prompt : "a simple blue square on a white background",
 				options: { provider: "gemini", apiKey: geminiKey }
 			)
 			hasImages  = response.hasImages()
@@ -193,7 +193,7 @@ public class aiImageTest extends BaseIntegrationTest {
 		executeWithTimeoutHandling(
 			"""
 			savedPath        = aiImage(
-				"a simple green triangle",
+				prompt : "a simple green triangle",
 				options: { outputFile: "#outputPath#" }
 			)
 			fileExistsResult = fileExists( savedPath )
@@ -216,7 +216,7 @@ public class aiImageTest extends BaseIntegrationTest {
 		// @formatter:off
 		executeWithTimeoutHandling(
 			"""
-			result       = aiImage( "a yellow star", options: { outputFile: "#outputPath#" } )
+			result       = aiImage( prompt: "a yellow star", options: { outputFile: "#outputPath#" } )
 			resultIsString = isSimpleValue( result )
 			""".replace( "#outputPath#", outputPath ),
 			context


### PR DESCRIPTION
- aiImage tests mixed positional and named args (parse error). Switch the
  three offending calls to use `prompt:` named arg consistently.
- AiImageRequest had a `static {}` block before its `property` declarations,
  which the parser rejects ("'property' was unexpected while parsing a box
  class"). Move the static block after the properties to match
  AiBaseRequest's ordering.
- testImageToolRegistered called `.isPresent()` on the result of
  `aiToolRegistry().get()`, which returns the tool directly (not an
  Optional). Switch to the registry's `has()` method.

https://claude.ai/code/session_01EDeKK4A41C7GZRVGd5XaER