### PR TITLE
Fix to Schema Builder populateArray and change default model to qwen3:06b

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -132,7 +132,7 @@ curl http://localhost:11434/api/tags  # Verify model availability
 - Use `variables.get("varName")` to extract BoxLang execution results from BoxLang execution context
 - Test class pattern: `extends BaseIntegrationTest` → access `runtime`, `context`, `variables` properties
 - Provider tests are `@Disabled` by default (require API keys in env vars like `OPENAI_API_KEY`)
-- Ollama tests require `docker compose up ollama` (auto-pulls `qwen2.5:0.5b-instruct`)
+- Ollama tests require `docker compose up ollama` (auto-pulls `qwen3:0.6b`)
 - **Debugging AI Provider HTTP responses**: Add `logResponseToConsole: true` to AI service provider config (OpenAI, Claude, etc.) to see raw API responses in console output - useful for debugging provider integration issues
 
 **BaseIntegrationTest provides:**
@@ -822,7 +822,7 @@ Complete settings from [ModuleConfig.bx](src/main/bx/ModuleConfig.bx#L103-L147):
             options: { timeout: 60 }
         },
         ollama: {
-            params: { model: "qwen2.5:0.5b-instruct" }
+            params: { model: "qwen3:0.6b" }
         }
     },
     timeout: 30,                      // Default HTTP timeout (seconds)
@@ -1280,7 +1280,7 @@ build/module/                # Compiled module (shadowJar output) - tests load f
 9. **Ollama model names**: Must include version tags
    ```javascript
    // ✅ Correct
-   params: { model: "qwen2.5:0.5b-instruct" }
+   params: { model: "qwen3:0.6b" }
 
    // ❌ Wrong - missing version tag
    params: { model: "qwen2.5" }  // ERROR: model not found

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,9 +61,9 @@ jobs:
         run: |
           echo "Waiting for Ollama to be ready..."
           sleep 20
-          echo "Making initial chat request to load qwen2.5:0.5b-instruct..."
+          echo "Making initial chat request to load qwen3:0.6b..."
           curl -s http://localhost:11434/api/chat -d '{
-            "model": "qwen2.5:0.5b-instruct",
+            "model": "qwen3:0.6b",
             "messages": [{"role": "user", "content": "Hi"}],
             "stream": false
           }' || echo "Chat model warming up..."

--- a/changelog.md
+++ b/changelog.md
@@ -284,7 +284,7 @@ What's New: <https://ai.ortusbooks.com/readme/release-history/2.1.0>
 	},
 	"ollama" : {
 		"params" : {
-			"model" : "qwen2.5:0.5b-instruct"
+			"model" : "qwen3:0.6b"
 		},
 		"options" : {
 			"baseUrl" : "http://my-ollama-server:11434/"

--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -11,7 +11,7 @@
 #    - Restrict port access using firewall rules (only expose what's needed)
 #
 # 2. MODELS - Customize for your use case:
-#    - Update the preloaded model in command section (default: qwen2.5:0.5b-instruct)
+#    - Update the preloaded model in command section (default: qwen3:0.6b)
 #    - Add multiple models: ollama pull model1 && ollama pull model2
 #    - For GPU support, add deploy.resources.reservations.devices config
 #
@@ -62,7 +62,7 @@ services:
       "ollama serve &
       sleep 10
       # Preload models
-      ollama pull qwen2.5:0.5b-instruct
+      ollama pull qwen3:0.6b
       ollama pull gemma3
       ollama pull nomic-embed-text
       wait"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command: |
       "ollama serve &
       sleep 10
-      ollama pull qwen2.5:0.5b-instruct
+      ollama pull qwen3:0.6b
       ollama pull nomic-embed-text
       wait"
     restart: unless-stopped

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Below is the full reference of every setting you can place under `settings` in `
                         "params": { "model": "claude-3-5-sonnet-20241022" }
                     },
                     "ollama": {
-                        "params": { "model": "qwen2.5:0.5b-instruct" }
+                        "params": { "model": "qwen3:0.6b" }
                     }
                 },
 

--- a/src/main/bx/models/providers/OllamaService.bx
+++ b/src/main/bx/models/providers/OllamaService.bx
@@ -26,7 +26,7 @@ class extends="OpenAiService" implements="IAiChatService, IAiEmbeddingsService" 
 		CAPABILITIES = [ "chat", "stream", "embeddings" ]
 		DEFAULT_CHAT_PARAMS = {
 			// Popular local models - users can override with any Ollama model
-			"model" : "qwen2.5:0.5b-instruct"
+			"model" : "qwen3:0.6b"
 		}
 		DEFAULT_EMBED_PARAMS = {
 			"model" : "nomic-embed-text"

--- a/src/main/bx/models/util/SchemaBuilder.bx
+++ b/src/main/bx/models/util/SchemaBuilder.bx
@@ -349,13 +349,11 @@ class {
 	 * @return Array of populated class instances
 	 */
 	static array function populateArray( required any classInstance, required any data ) {
-		var type = isSimpleValue( arguments.classInstance ) 
-			? "simple" 
-			: arguments.classInstance.getClass().getName()=="ortus.boxlang.runtime.types.Struct"
+		var type = arguments.classInstance instanceof "ortus.boxlang.runtime.types.Struct"
 					? "struct"
-					: arguments.classInstance.getClass().getname()=="ortus.boxlang.runtime.types.Array"
+					: arguments.classInstance instanceof "ortus.boxlang.runtime.types.Array"
 						? "array"
-						: arguments.classInstance.getClass().getName();
+						: arguments.classInstance;
 				
 		// Parse JSON if data is a string
 		var dataArray = isSimpleValue( arguments.data )

--- a/src/main/bx/models/util/SchemaBuilder.bx
+++ b/src/main/bx/models/util/SchemaBuilder.bx
@@ -367,11 +367,7 @@ class {
 			var appendMe = (["struct","array"]).findNoCase(type) 
 				? item
 				:  populateClass( arguments.classInstance, item );
-			// Create new instance for each item
-			//systemOutput(getMetadata( arguments.classInstance ))
-			//var className = getMetadata( arguments.classInstance ).name;
-			//var newInstance = createObject( className );
-			//populateClass( newInstance, item )
+
 			results.append( appendMe );
 		}
 

--- a/src/main/bx/models/util/SchemaBuilder.bx
+++ b/src/main/bx/models/util/SchemaBuilder.bx
@@ -349,6 +349,14 @@ class {
 	 * @return Array of populated class instances
 	 */
 	static array function populateArray( required any classInstance, required any data ) {
+		var type = isSimpleValue( arguments.classInstance ) 
+			? "simple" 
+			: arguments.classInstance.getClass().getName()=="ortus.boxlang.runtime.types.Struct"
+					? "struct"
+					: arguments.classInstance.getClass().getname()=="ortus.boxlang.runtime.types.Array"
+						? "array"
+						: arguments.classInstance.getClass().getName();
+				
 		// Parse JSON if data is a string
 		var dataArray = isSimpleValue( arguments.data )
 			? jsonDeserialize( arguments.data )
@@ -358,11 +366,15 @@ class {
 
 		// Populate each item
 		for( var item in dataArray ) {
+			var appendMe = (["struct","array"]).findNoCase(type) 
+				? item
+				:  populateClass( arguments.classInstance, item );
 			// Create new instance for each item
-			var className = getMetadata( arguments.classInstance ).name;
-			var newInstance = createObject( className );
-
-			results.append( populateClass( newInstance, item ) );
+			//systemOutput(getMetadata( arguments.classInstance ))
+			//var className = getMetadata( arguments.classInstance ).name;
+			//var newInstance = createObject( className );
+			//populateClass( newInstance, item )
+			results.append( appendMe );
 		}
 
 		return results;

--- a/src/test/java/ortus/boxlang/ai/providers/OllamaTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/OllamaTest.java
@@ -73,7 +73,7 @@ public class OllamaTest extends BaseIntegrationTest {
 		    result = aiChat(
 		        messages = "What is 2 + 2? Answer with just the number.",
 		        options = {
-		            "model": "qwen2.5:0.5b-instruct",
+		            "model": "qwen3:0.6b",
 		    	 	logResponseToConsole: true
 		        }
 		    )
@@ -244,7 +244,7 @@ public class OllamaTest extends BaseIntegrationTest {
 		assertThat( variables.get( "fullResponse" ) ).isNotNull();
 		var	fullResponse	= variables.get( "fullResponse" ).toString();
 		// Assert the tool was actually invoked (mechanism is working)
-		// Note: qwen2.5:0.5b-instruct is a very small model and may not reliably
+		// Note: qwen3:0.6b is a very small model and may not reliably
 		// incorporate tool results into its final answer - we assert invocation, not the value.
 		var	toolCallCount	= variables.getAsInteger( Key.of( "toolCallCount" ) );
 		Assumptions.assumeTrue(


### PR DESCRIPTION
# Description

Added class type checking in SchemaBuilder.populateArray() to ensure that the iteration value was correct.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [ ] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
