### PR TITLE
Fix (183): incorrect string escaping and interpolation in `/examples/`, multiple scripts

### DIFF
--- a/examples/advanced/02-cohere-embeddings-example.bxs
+++ b/examples/advanced/02-cohere-embeddings-example.bxs
@@ -208,7 +208,7 @@ println( "=== Semantic Search Results ===" )
 println( "Query: #query#" )
 println()
 results.each( (result, idx) => {
-	println( "##idx#. [#numberFormat( result.similarity * 100, '0.00' )#%] #result.text#" )
+	println( "###idx#. [#numberFormat( result.similarity * 100, '0.00' )#%] #result.text#" )
 } )
 println()
 

--- a/examples/agents/06-sub-agents.bxs
+++ b/examples/agents/06-sub-agents.bxs
@@ -15,49 +15,49 @@ println( "" )
 mathAgent = aiAgent(
     name: "MathAgent",
     description: "A mathematics expert that can solve calculations and explain math concepts",
-    instructions: """
+    instructions: "
         You are a mathematics expert. You help with:
         - Mathematical calculations
         - Explaining math concepts
         - Solving equations
         - Statistical analysis
         Be precise and show your work when solving problems.
-    """
+    "
 )
 
 // 2. Code Agent - handles coding tasks
 codeAgent = aiAgent(
     name: "CodeAgent",
     description: "A programming expert that can write, review, and explain code",
-    instructions: """
+    instructions: "
         You are a programming expert. You help with:
         - Writing code in various languages
         - Code review and optimization
         - Debugging issues
         - Explaining programming concepts
         Provide clean, well-documented code examples.
-    """
+    "
 )
 
 // 3. Research Agent - handles research and fact-finding
 researchAgent = aiAgent(
     name: "ResearchAgent",
     description: "A research specialist that can gather information and provide summaries",
-    instructions: """
+    instructions: "
         You are a research specialist. You help with:
         - Finding relevant information on topics
         - Summarizing complex subjects
         - Comparing different options or solutions
         - Providing factual, well-organized responses
         Cite sources when possible and present information clearly.
-    """
+    "
 )
 
 // Create the main orchestrator agent with sub-agents
 mainAgent = aiAgent(
     name: "OrchestratorAgent",
     description: "A main coordinator that delegates tasks to specialized sub-agents",
-    instructions: """
+    instructions: "
         You are a task orchestrator. You have access to specialized sub-agents:
         - MathAgent: For mathematical calculations and concepts
         - CodeAgent: For programming tasks and code review
@@ -66,7 +66,7 @@ mainAgent = aiAgent(
         Analyze each user request and delegate to the appropriate sub-agent when needed.
         For simple queries, answer directly. For specialized tasks, use the delegation tools.
         Summarize the sub-agent's response in a user-friendly way.
-    """,
+    ",
     subAgents: [ mathAgent, codeAgent, researchAgent ]
 )
 

--- a/examples/basic/03-return-formats-example.bxs
+++ b/examples/basic/03-return-formats-example.bxs
@@ -65,7 +65,7 @@ println()
 // 6. JSON format - Parsed JSON object
 println( "=== JSON Format ===" )
 jsonPipeline = aiMessage()
-    .user( "Return JSON: {\"language\": \"BoxLang\", \"version\": \"2.0\", \"cool\": true}" )
+    .user( 'Return JSON: {"language": "BoxLang", "version": "2.0", "cool": true}' )
     .toDefaultModel()
     .asJson()
 

--- a/examples/basic/04-json-xml-formats-example.bxs
+++ b/examples/basic/04-json-xml-formats-example.bxs
@@ -12,7 +12,7 @@ println( "=== JSON Format ===" )
 
 // Method 1: Using asJson() helper
 jsonResult = aiMessage()
-    .user( "Return JSON: {\"name\": \"John Doe\", \"age\": 30, \"city\": \"New York\"}" )
+    .user( 'Return JSON: {"name": "John Doe", "age": 30, "city": "New York"}' )
     .toDefaultModel()
     .asJson()
     .run()
@@ -40,7 +40,7 @@ println()
 println( "=== JSON Format - Complex Objects ===" )
 
 complexJson = aiMessage()
-    .user( """
+    .user( '
         Return JSON with this structure:
         {
             "users": [
@@ -49,7 +49,7 @@ complexJson = aiMessage()
             ],
             "total": 2
         }
-    """ )
+    ' )
     .toDefaultModel()
     .asJson()
     .run()
@@ -66,7 +66,7 @@ println()
 println( "=== JSON Format + Transform ===" )
 
 transformed = aiMessage()
-    .user( "Return JSON: {\"message\": \"hello world\", \"count\": 5}" )
+    .user( 'Return JSON: {"message": "hello world", "count": 5}' )
     .toDefaultModel()
     .asJson()
     .transform( (data) => {
@@ -87,14 +87,14 @@ println( "=== XML Format ===" )
 
 // Method 1: Using asXml() helper
 xmlResult = aiMessage()
-    .user( """
+    .user( "
         Return XML:
         <person>
             <name>Jane Doe</name>
             <age>28</age>
             <city>San Francisco</city>
         </person>
-    """ )
+    " )
     .toDefaultModel()
     .asXml()
     .run()
@@ -108,14 +108,14 @@ println()
 
 // Method 2: Using returnFormat option
 xmlResult2 = aiChat(
-    """
+    "
     Return XML for a book:
     <book>
         <title>BoxLang Guide</title>
         <author>Ortus Solutions</author>
         <year>2025</year>
     </book>
-    """,
+    ",
     {},
     { returnFormat: "xml" }
 )
@@ -131,7 +131,7 @@ println()
 println( "=== XML Format - Complex Documents ===" )
 
 catalogXml = aiMessage()
-    .user( """
+    .user( '
         Return XML catalog:
         <catalog>
             <book id="1">
@@ -143,7 +143,7 @@ catalogXml = aiMessage()
                 <price>39.99</price>
             </book>
         </catalog>
-    """ )
+    ' )
     .toDefaultModel()
     .asXml()
     .run()
@@ -159,7 +159,7 @@ println()
 // ==============================================================================
 println( "=== Return Format Comparison ===" )
 
-prompt = "Return JSON: {\"status\": \"success\", \"code\": 200}"
+prompt = 'Return JSON: {"status": "success", "code": 200}'
 
 // Raw format - full response
 rawResponse = aiChat( prompt, {}, { returnFormat: "raw" } )

--- a/examples/loaders/01-text-loader.bxs
+++ b/examples/loaders/01-text-loader.bxs
@@ -78,7 +78,7 @@ try {
 
 	println( "Split into #chunks.len()# chunks" )
 	chunks.each( ( chunk, idx ) => {
-		println( "  Chunk ##idx#: #left( chunk.content, 50 )#..." )
+		println( "  Chunk ###idx#: #left( chunk.content, 50 )#..." )
 	})
 	println()
 
@@ -131,7 +131,7 @@ try {
 
 	println( "Loaded #allDocs.len()# documents from #files.len()# files" )
 	allDocs.each( ( doc, idx ) => {
-		println( "  Doc ##idx#: #left( doc.content, 40 )#..." )
+		println( "  Doc ###idx#: #left( doc.content, 40 )#..." )
 	})
 
 	// Cleanup temp files

--- a/examples/loaders/02-csv-loader.bxs
+++ b/examples/loaders/02-csv-loader.bxs
@@ -43,7 +43,7 @@ try {
 
 	documents.each( ( doc, idx ) => {
 		if ( idx <= 3 ) {  // Show first 3
-			println( "Product ##idx#:" )
+			println( "Product ###idx#:" )
 			println( "  Name: #doc.metadata.name#" )
 			println( "  Category: #doc.metadata.category#" )
 			println( "  Price: $#doc.metadata.price#" )

--- a/examples/loaders/05-markdown-loader.bxs
+++ b/examples/loaders/05-markdown-loader.bxs
@@ -13,20 +13,20 @@ println()
 // Create a sample Markdown file
 mdFile = getTempDirectory() & "guide-" & createUUID() & ".md"
 fileWrite( mdFile, "
-# BoxLang AI Module Guide
+## BoxLang AI Module Guide
 
-## Introduction
+#### Introduction
 
 The BoxLang AI module provides a unified interface for working with multiple AI providers.
 
-### Key Features
+###### Key Features
 
 - **Multiple Providers**: OpenAI, Claude, Gemini, Ollama, and more
 - **Streaming Support**: Real-time response streaming
 - **Memory Systems**: Conversation history and context management
 - **Tool Calling**: AI agents can call custom functions
 
-## Quick Start
+#### Quick Start
 
 ```javascript
 // Simple chat example
@@ -34,7 +34,7 @@ response = aiChat( ""Hello, AI!"" )
 println( response )
 ```
 
-### Advanced Usage
+###### Advanced Usage
 
 For production applications, consider using:
 
@@ -43,7 +43,7 @@ For production applications, consider using:
 3. **Tools** for function calling
 4. **Pipelines** for multi-step processes
 
-## Best Practices
+#### Best Practices
 
 > **Important:** Always handle API keys securely using environment variables.
 
@@ -52,7 +52,7 @@ For production applications, consider using:
 - Cache responses when possible
 - Monitor token usage
 
-## Conclusion
+#### Conclusion
 
 The BoxLang AI module simplifies AI integration in your applications.
 
@@ -122,7 +122,7 @@ try {
 	message = aiMessage()
 		.system( "Answer questions about this documentation: ${context}" )
 		.user( "What are the key features of the BoxLang AI module?" )
-		.setContext( mdContent )
+		.setContext( {content: mdContent} )
 
 	println( "Query: What are the key features?" )
 	println( "Answer: " & aiChat( message ) )
@@ -141,7 +141,7 @@ try {
 
 	println( "Found #codeBlocks.len()# code block(s):" )
 	codeBlocks.each( ( code, idx ) => {
-		println( "  Code ##idx#: #left( code, 40 )#..." )
+		println( "  Code ###idx#: #left( code, 40 )#..." )
 	})
 	println()
 
@@ -162,7 +162,7 @@ try {
 	println( "Split documentation into #chunks.len()# chunks" )
 	chunks.each( ( chunk, idx ) => {
 		if ( idx <= 3 ) {
-			println( "  Chunk ##idx#: #left( chunk.content, 50 )#..." )
+			println( "  Chunk ###idx#: #left( chunk.content, 50 )#..." )
 		}
 	})
 	println()
@@ -173,17 +173,17 @@ try {
 
 	readmeFile = getTempDirectory() & "README-" & createUUID() & ".md"
 	fileWrite( readmeFile, "
-# My Project
+## My Project
 
 A simple project for demonstration.
 
-## Installation
+#### Installation
 
 ```bash
 npm install my-project
 ```
 
-## Usage
+#### Usage
 
 Import and use:
 
@@ -192,7 +192,7 @@ import { MyClass } from 'my-project';
 const instance = new MyClass();
 ```
 
-## License
+#### License
 
 MIT License - See LICENSE file for details.
 " )

--- a/examples/loaders/06-directory-loader.bxs
+++ b/examples/loaders/06-directory-loader.bxs
@@ -18,8 +18,8 @@ directoryCreate( testDir )
 files = [
 	{ name: "intro.txt", content: "Introduction to BoxLang AI Module. A comprehensive guide to getting started." },
 	{ name: "features.txt", content: "Key features include multi-provider support, streaming, memory, and tools." },
-	{ name: "quickstart.md", content: "# Quick Start\n\nInstall and use BoxLang AI in minutes." },
-	{ name: "api.md", content: "# API Reference\n\n## aiChat()\n\nBasic chat function." },
+	{ name: "quickstart.md", content: "## Quick Start\n\nInstall and use BoxLang AI in minutes." },
+	{ name: "api.md", content: "## API Reference\n\n#### aiChat()\n\nBasic chat function." },
 	{ name: "changelog.txt", content: "v1.0.0 - Initial release with OpenAI support" }
 ]
 
@@ -40,7 +40,7 @@ try {
 
 	println( "Loaded #documents.len()# documents from directory" )
 	documents.each( ( doc, idx ) => {
-		println( "  ##idx#: #doc.metadata.source ?: 'unknown'#" )
+		println( "  ###idx#: #doc.metadata.source ?: 'unknown'#" )
 	})
 	println()
 
@@ -59,7 +59,7 @@ try {
 
 	println( "Loaded #txtDocs.len()# .txt files:" )
 	txtDocs.each( ( doc, idx ) => {
-		println( "  ##idx#: #doc.metadata.source ?: 'unknown'#" )
+		println( "  ###idx#: #doc.metadata.source ?: 'unknown'#" )
 	})
 	println()
 
@@ -70,8 +70,8 @@ try {
 	// Create subdirectory with files
 	subDir = testDir & "advanced/"
 	directoryCreate( subDir )
-	fileWrite( subDir & "agents.md", "# Agents\n\nAdvanced agent patterns and workflows." )
-	fileWrite( subDir & "memory.md", "# Memory\n\nConversation history and context management." )
+	fileWrite( subDir & "agents.md", "## Agents\n\nAdvanced agent patterns and workflows." )
+	fileWrite( subDir & "memory.md", "## Memory\n\nConversation history and context management." )
 
 	dirLoaderRecursive = new src.main.bx.models.loaders.DirectoryLoader(
 		source: testDir,
@@ -117,7 +117,7 @@ try {
 	println( "Document index created:" )
 	docIndex.each( entry => {
 		if ( entry.id <= 5 ) {
-			println( "  ##entry.id#: #entry.filename# (#entry.contentLength# chars)" )
+			println( "  ###entry.id#: #entry.filename# (#entry.contentLength# chars)" )
 		}
 	})
 	println()

--- a/examples/loaders/07-http-loader.bxs
+++ b/examples/loaders/07-http-loader.bxs
@@ -62,7 +62,7 @@ try {
 	println( "Loaded #allDocs.len()# documents from multiple URLs" )
 	allDocs.each( ( doc, idx ) => {
 		content = jsonDeserialize( doc.content )
-		println( "  ##idx#: #content.title#" )
+		println( "  ###idx#: #content.title#" )
 	})
 	println()
 

--- a/examples/loaders/08-web-crawler.bxs
+++ b/examples/loaders/08-web-crawler.bxs
@@ -45,7 +45,7 @@ try {
 
 	println( "Crawled #multiDocs.len()# page(s)" )
 	multiDocs.each( ( doc, idx ) => {
-		println( "  Page ##idx#: #doc.metadata.url ?: 'unknown'#" )
+		println( "  Page ###idx#: #doc.metadata.url ?: 'unknown'#" )
 	})
 	println()
 

--- a/examples/loaders/09-sql-loader.bxs
+++ b/examples/loaders/09-sql-loader.bxs
@@ -46,7 +46,7 @@ try {
 
 	println( "Loaded #simulatedDocs.len()# documents from database" )
 	simulatedDocs.each( ( doc, idx ) => {
-		println( "  ##idx#: #doc.content#" )
+		println( "  ###idx#: #doc.content#" )
 	})
 	println()
 
@@ -71,7 +71,7 @@ try {
 
 	println( "Converted #employeeDocs.len()# rows to documents:" )
 	employeeDocs.each( ( doc, idx ) => {
-		println( "  ##idx#: #doc.content#" )
+		println( "  ###idx#: #doc.content#" )
 	})
 	println()
 
@@ -141,7 +141,7 @@ try {
 	println( "Loaded #products.len()# products from database" )
 	println( "Prepared for embeddings:" )
 	productTexts.each( ( text, idx ) => {
-		println( "  ##idx#: #left( text, 50 )#..." )
+		println( "  ###idx#: #left( text, 50 )#..." )
 	})
 	println()
 	println( "💡 Generate embeddings:" )

--- a/examples/pipelines/01-simple-pipeline.bxs
+++ b/examples/pipelines/01-simple-pipeline.bxs
@@ -105,7 +105,7 @@ texts = [
 
 texts.each( ( text, index ) => {
     result = processor.run({ text: text })
-    println( "Text ##index#: '#text#'" )
+    println( "Text ###index#: '#text#'" )
     println( "Sentiment: #result.sentiment# #result.emoji# (Score: #result.score#/5)" )
     println( "" )
 } )

--- a/examples/pipelines/06-code-extractor.bxs
+++ b/examples/pipelines/06-code-extractor.bxs
@@ -95,7 +95,7 @@ function greet( name ) {
 
 	println( "Extracted #allCodeBlocks.len()# code blocks:" )
 	allCodeBlocks.each( ( block, idx ) => {
-		println( "  Block ##idx#:" )
+		println( "  Block ###idx#:" )
 		println( "  " & left( block, 40 ) & "..." )
 		println()
 	})

--- a/examples/pipelines/07-text-cleaner.bxs
+++ b/examples/pipelines/07-text-cleaner.bxs
@@ -138,7 +138,7 @@ Paragraph 3"
 	println( "Example 7: Remove Special Characters" )
 	println( "─".repeat( 50 ) )
 
-	specialChars = "Hello! @#$% This & text * has () special [] characters."
+	specialChars = "Hello! @$% This & text * has () special [] characters."
 
 	charCleaner = new src.main.bx.models.transformers.TextCleanerTransformer(
 		config: { removeSpecialChars: true }
@@ -162,7 +162,7 @@ Paragraph 3"
    text    with    multiple
 
 
-   problems!!!   @#$
+   problems!!!   @$
 
 "
 
@@ -214,7 +214,7 @@ with blank lines.
 
 	println( "Cleaned #cleanedDocs.len()# documents for embeddings:" )
 	cleanedDocs.each( ( doc, idx ) => {
-		println( "  ##idx#: #doc#" )
+		println( "  ###idx#: #doc#" )
 	})
 	println()
 	println( "💡 Now ready for: embeddings = aiEmbeddings( cleanedDocs )" )

--- a/examples/structured/03-array-extraction.bxs
+++ b/examples/structured/03-array-extraction.bxs
@@ -39,7 +39,7 @@ println( "Total tasks: #tasks.len()#" )
 println( "" )
 
 tasks.each( ( task, index ) => {
-    println( "Task ##index#: #task.getTitle()#" )
+    println( "Task ###index#: #task.getTitle()#" )
     println( "  Priority: #task.getPriority()#" )
     println( "  Estimated: #task.getEstimatedHours()# hours" )
     println( "  Assignee: #task.getAssignee()#" )

--- a/examples/structured/06-pipeline-structured-output.bxs
+++ b/examples/structured/06-pipeline-structured-output.bxs
@@ -45,7 +45,7 @@ println( "" )
 reviews.each( ( review, index ) => {
     analysis = sentimentPipeline.run({ text: review })
 
-    println( "Review ##index#:" )
+    println( "Review ###index#:" )
     println( 'Text: "#left(review, 50)#..."' )
     println( "Sentiment: #analysis.getSentiment()#" )
     println( "Score: #analysis.getScore()#" )


### PR DESCRIPTION
Most of the problems noted in this issue were blocking, so that the scripts in question could not be executed because of parsing errors. The fixes adhere to BoxLang standards for string escaping and interpolation (see issue for background information).

Fixes for each category of issue:
* Unnecessary escaping of normal string delimiters `\"` --> FIX: simple replacements with `"`
* Incorrect escaping of strings intended for JSON/XML/multi-line
  * JSON/XML-like quotation mark escaping `\"` --> FIX: removing backslashes, use double-double quotes for correctly escaped double quote literals in JSON/XML `""`, OR use single quotes to delimit a string that contains double quotes
  * Java-style triple quotes for multi-line text `"""` --> FIX: removing triple quotes, use double quotes to delimit these multi-line strings, and escape anything within as needed. In a JSON string, which requires double quote literals as part of its spec, use single quotes as a delimiter.
* String interpolation mistakes (unescaped hash symbol ('#')) --> FIX: add additional hash symbols where needed to escape the intended literals
  * Attempt to output `#` literals _near intended interpolation_ (ie. `println( "Product ##idx#:" )` --> `println( "Product ###idx#:" )` outputs `Product #1234:`)
  * Attempt to output `#` literals _without_ nearby interpolation (ie. Markdown headers. If for Markdown, simply double the number of pound signs: for a 3rd-level header `###`, replace with 6: `######`)


## Jira/Github Issues

Closes Issue #183

## Type of change

-   [x] Bug Fix

## Checklist

-   [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)