### PR TITLE
feat(BedrockService): add tool-use support for Claude models

### DIFF
--- a/src/main/bx/models/providers/BedrockService.bx
+++ b/src/main/bx/models/providers/BedrockService.bx
@@ -317,9 +317,12 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 			if ( msg.role == "system" ) {
 				systemPrompt = isSimpleValue( msg.content ) ? msg.content : msg.content.toString();
 			} else {
+				// Preserve structured content (arrays of tool_use / tool_result blocks)
+				// as-is; only flatten non-simple, non-array content. Flattening arrays
+				// with toString() would break multi-turn tool conversations.
 				conversationMessages.append( {
 					"role"    : msg.role,
-					"content" : isSimpleValue( msg.content ) ? msg.content : msg.content.toString()
+					"content" : ( isSimpleValue( msg.content ) || isArray( msg.content ) ) ? msg.content : msg.content.toString()
 				} );
 			}
 		}
@@ -328,6 +331,12 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 
 		if ( len( trim( systemPrompt ) ) ) {
 			result[ "system" ] = systemPrompt;
+		}
+
+		// Add tool support if tools are present. Bedrock's Claude Messages API uses
+		// the same tool schema as the direct Anthropic Messages API.
+		if ( arguments.params?.tools?.len() ) {
+			result[ "tools" ] = formatToolsForClaude( arguments.params.tools );
 		}
 
 		return result;
@@ -641,6 +650,72 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 	}
 
 	/**
+	 * Format tools for the Bedrock Claude Messages API. Identical schema to the
+	 * direct Anthropic Messages API.
+	 * @see https://docs.anthropic.com/en/api/messages#body-tools
+	 *
+	 * @tools The tools to format
+	 *
+	 * @return An array of tools formatted for Claude
+	 */
+	private array function formatToolsForClaude( required array tools ) {
+		var claudeTools = [];
+
+		for ( var tool in arguments.tools ) {
+			var argumentsSchema = tool.getArgumentsSchema();
+			claudeTools.append( {
+				"name"        : tool.getName(),
+				"description" : tool.getDescription(),
+				"input_schema": {
+					"type"      : "object",
+					"properties": argumentsSchema.properties,
+					"required"  : argumentsSchema.required
+				}
+			} );
+		}
+
+		return claudeTools;
+	}
+
+	/**
+	 * Execute a Claude tool call returned by Bedrock and append the tool_result
+	 * message to the conversation.
+	 *
+	 * @toolCall    The tool call block from Claude: { type:"tool_use", id:"", name:"toolName", input:{} }
+	 * @chatRequest The original chat request containing the tool
+	 */
+	private function executeBedrockTool( required struct toolCall, required AiChatRequest chatRequest ) {
+		var messages    = arguments.chatRequest.getMessages();
+		var toolAttempt = arguments.chatRequest.getTool( arguments.toolCall.name );
+
+		if ( toolAttempt.isPresent() ) {
+			var tool = toolAttempt.get();
+			messages.append( {
+				"role"   : "user",
+				"content": [ {
+					"type"        : "tool_result",
+					"tool_use_id" : arguments.toolCall.id,
+					"content"     : tool.invoke( args: arguments.toolCall.input, chatRequest: arguments.chatRequest )
+				} ]
+			} );
+		} else {
+			writeLog(
+				text: "Unable to find tool named: [#arguments.toolCall.name#]",
+				type: "warning",
+				log : "ai"
+			);
+			messages.append( {
+				"role"   : "user",
+				"content": [ {
+					"type"        : "tool_result",
+					"tool_use_id" : arguments.toolCall.id,
+					"content"     : "Tool ['#arguments.toolCall.name#'] not found in chat request"
+				} ]
+			} );
+		}
+	}
+
+	/**
 	 * Override chat to handle Bedrock-specific request signing and model transformation
 	 *
 	 * @chatRequest      The AiChatRequest object
@@ -740,6 +815,50 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 					timestamp           : now()
 				}
 			);
+		}
+
+		// -------------------------------------------------------------------------------------------
+		// --- Handle Claude tool-use (native tool_use blocks from the Bedrock Claude Messages API) ---
+		// -------------------------------------------------------------------------------------------
+		if ( modelFamily == "claude" && result.keyExists( "content" ) && isArray( result.content ) ) {
+			var usingTools = false;
+			for ( var contentBlock in result.content ) {
+				if ( contentBlock?.type == "tool_use" ) {
+					usingTools = true;
+					break;
+				}
+			}
+
+			if ( usingTools ) {
+				var maxAllowed = arguments.chatRequest.getMaxInteractions() > 0 ? arguments.chatRequest.getMaxInteractions() : variables.maxInteractions;
+				if ( arguments.interactionCount >= maxAllowed ) {
+					writeLog(
+						text: "Max tool call interactions (#maxAllowed#) exceeded",
+						type: "error",
+						log : "ai"
+					);
+					throw(
+						type   : "MaxInteractionsExceeded",
+						message: "Tool calls exceeded maximum allowed interactions (#maxAllowed#). This may indicate an infinite loop."
+					);
+				}
+
+				var toolCalls = result.content.filter( contentBlock -> contentBlock?.type == "tool_use" );
+
+				// Record the assistant turn (text + tool_use blocks)
+				arguments.chatRequest.getMessages().append( {
+					"role"    : "assistant",
+					"content" : result.content
+				} );
+
+				// Execute each requested tool, appending tool_result messages
+				for ( var toolCall in toolCalls ) {
+					executeBedrockTool( toolCall, arguments.chatRequest );
+				}
+
+				// Recurse with tool results now in context
+				return chat( arguments.chatRequest, arguments.interactionCount + 1 );
+			}
 		}
 
 		// Handle response based on return format

--- a/src/test/java/ortus/boxlang/ai/providers/BedrockTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/BedrockTest.java
@@ -1,0 +1,135 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.ai.providers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.ai.BaseIntegrationTest;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Struct;
+
+/**
+ * Live integration tests for the AWS Bedrock provider.
+ *
+ * These hit real Bedrock and are skipped unless AWS credentials are present in
+ * the environment (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION, and
+ * AWS_SESSION_TOKEN for SSO). The model must also be enabled in that
+ * account/region — note that newer Claude models are only reachable on-demand
+ * via an inference-profile id (e.g. "us.anthropic.claude-3-5-sonnet-...");
+ * adjust BEDROCK_MODEL to one your test account can invoke.
+ *
+ * For deterministic, credential-free coverage of the tool-use logic see
+ * BedrockToolUseTest.
+ */
+public class BedrockTest extends BaseIntegrationTest {
+
+	private static final String	BEDROCK_MODEL	= "anthropic.claude-3-5-sonnet-20240620-v1:0";
+
+	private String				awsAccessKeyId;
+	private String				awsSecretAccessKey;
+	private String				awsSessionToken;
+	private String				awsRegion;
+
+	@BeforeEach
+	public void beforeEach() {
+		// Bedrock authenticates via the AWS credential chain, supplied here as a
+		// struct apiKey (same pattern as BedrockServiceTest).
+		awsAccessKeyId		= dotenv.get( "AWS_ACCESS_KEY_ID", "" );
+		awsSecretAccessKey	= dotenv.get( "AWS_SECRET_ACCESS_KEY", "" );
+		awsSessionToken		= dotenv.get( "AWS_SESSION_TOKEN", "" );
+		awsRegion			= dotenv.get( "AWS_REGION", "us-east-1" );
+
+		moduleRecord.settings.put( "provider", "bedrock" );
+		Struct credentials = new Struct();
+		credentials.put( "awsAccessKeyId", awsAccessKeyId );
+		credentials.put( "awsSecretAccessKey", awsSecretAccessKey );
+		credentials.put( "region", awsRegion );
+		if ( !awsSessionToken.isEmpty() ) {
+			credentials.put( "awsSessionToken", awsSessionToken );
+		}
+		moduleRecord.settings.put( "apiKey", credentials );
+	}
+
+	private boolean hasAwsCredentials() {
+		return !awsAccessKeyId.isEmpty() && !awsSecretAccessKey.isEmpty();
+	}
+
+	@DisplayName( "Test Bedrock AI chat" )
+	@Test
+	public void testBedrock() {
+		if ( !hasAwsCredentials() ) {
+			System.out.println( "Skipping testBedrock - AWS credentials not configured in .env" );
+			return;
+		}
+
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+			result    = aiChat( messages = "what is boxlang?", options = { model: "%s" } )
+			answerLen = len( result )
+			println( result )
+			""".formatted( BEDROCK_MODEL ),
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "result" ) ) ).isInstanceOf( String.class );
+		assertThat( variables.getAsInteger( Key.of( "answerLen" ) ) ).isGreaterThan( 0 );
+	}
+
+	@DisplayName( "Test Bedrock Tools" )
+	@Test
+	public void testBedrockTools() {
+		if ( !hasAwsCredentials() ) {
+			System.out.println( "Skipping testBedrockTools - AWS credentials not configured in .env" );
+			return;
+		}
+
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+			tool = aiTool(
+				"get_weather",
+				"Get current temperature for a given location.",
+				location => {
+					if( location contains "Kansas City" ) {
+						return "85"
+					}
+
+					if( location contains "San Salvador" ){
+						return "90"
+					}
+
+					return "unknown";
+				}).describeLocation( "City and country e.g. Bogotá, Colombia" )
+
+			result = aiChat(
+				messages = "How hot is it in Kansas City? What about San Salvador? Answer with only the name of the warmer city, nothing else.",
+				params   = { tools: [ tool ] },
+				options  = { model: "%s", logResponseToConsole: true } )
+			println( result )
+			""".formatted( BEDROCK_MODEL ),
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "result" ) ) ).isEqualTo( "San Salvador" );
+	}
+
+}


### PR DESCRIPTION
transformRequestForClaude() omitted the `tools` field, so agents / aiChat calls with provider=bedrock never sent tool definitions to Bedrock. Claude then emitted tool calls as plain <tool_call> text and hallucinated the results; the loop returned that as the final answer.

- Inject formatToolsForClaude(params.tools) into the Claude request body
- Preserve structured (array) message content so tool_use / tool_result blocks round-trip instead of being toString()-flattened
- Detect native tool_use blocks in the Bedrock Claude response, execute the tools, append tool_result messages, and recurse (parity with ClaudeService)
- Add BedrockTest (live integration, credential-gated, mirrors ClaudeTest)

Fixes ortus-boxlang/bx-ai#189

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ai/issues

## Type of change

Please delete options that are not relevant.

-   [x] Bug Fix
-   [ ] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
