### PR TITLE
fix: rename mcpServer param to targetServer to resolve import collision

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🪲 Fixed
+
+- **MCPRequestProcessor CORS parameter collision**: Renamed the `mcpServer` parameter in `handleCORSPreflight()` to `targetServer` to avoid a case-insensitive name collision with the `MCPServer` import, which caused the stricter BoxLang compiler to reject the file and 500 every MCP request.
+
 ## [3.2.0] - 2026-05-14
 
 ### 🥊 New Features

--- a/src/main/bx/models/mcp/MCPRequestProcessor.bx
+++ b/src/main/bx/models/mcp/MCPRequestProcessor.bx
@@ -371,7 +371,7 @@ class {
 	 *
 	 * @return The populated response struct
 	 */
-	private static  struct function handleCORSPreflight( required struct response, required any mcpServer ) {
+	private static  struct function handleCORSPreflight( required struct response, required any targetServer ) {
 		arguments.response.headers[ "Access-Control-Allow-Methods" ] = "POST, GET, OPTIONS";
 		arguments.response.headers[ "Access-Control-Allow-Headers" ] = "Content-Type, Authorization, X-API-Key";
 		arguments.response.headers[ "Access-Control-Max-Age" ] = "86400";


### PR DESCRIPTION
The stricter BoxLang compiler rejects a function parameter whose name
matches an import (case-insensitively). handleCORSPreflight() had a
`mcpServer` parameter that collided with `import ...MCPServer`, causing
every MCP request to 500 with a compile error. Renamed to `targetServer`
— the parameter was unused in the body and the sole caller already passes
positionally, so no other changes are needed.

Scanned all 161 .bx files; no other collisions found.

https://claude.ai/code/session_01Md6qGmtSgnJVVQchfnSsuK