### PR TITLE
Fix @AITool scan schema generation for real parameter names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🪲 Fixed
+
+- **`@AITool` scan generates wrong parameter schema**: `aiToolRegistry().scanClass()` was wrapping annotated methods in a generic `(args) =>` lambda. `getArgumentsSchema()` introspected that wrapper and produced a single `args` property instead of the actual method parameters (e.g., `orderId`), and the `required` array was always empty for scanned tools. Fixed by storing the original method's parameter metadata (`name`, `type`, `required`) on the `ClosureTool` via `setMethodParameters()` and using it during schema generation when present. The wrapper lambda was also corrected to forward named arguments via the `arguments` scope, ensuring invocation works correctly once the schema exposes real parameter names.
+
 ## [3.3.0] - 2026-05-30
 
 ### 🥊 Added

--- a/src/main/bx/models/registry/AIToolRegistry.bx
+++ b/src/main/bx/models/registry/AIToolRegistry.bx
@@ -164,7 +164,7 @@ class extends="BaseRegistry" {
 				var tool = new ClosureTool(
 					toolName,
 					toolDescription,
-					() => invoke( targetInstance, methodName, arguments.filter( ( k, v ) => k != "_chatRequest" ) )
+					() => invoke( targetInstance, methodName, arguments )
 				)
 
 				// Store original method parameter metadata so getArgumentsSchema() sees real param names/types

--- a/src/main/bx/models/registry/AIToolRegistry.bx
+++ b/src/main/bx/models/registry/AIToolRegistry.bx
@@ -164,8 +164,15 @@ class extends="BaseRegistry" {
 				var tool = new ClosureTool(
 					toolName,
 					toolDescription,
-					( args ) => invoke( targetInstance, methodName, args )
+					() => invoke( targetInstance, methodName, arguments.filter( ( k, v ) => k != "_chatRequest" ) )
 				)
+
+				// Store original method parameter metadata so getArgumentsSchema() sees real param names/types
+				tool.setMethodParameters( ( fn.parameters ?: [] ).map( p => ({
+					name     : p.name,
+					type     : p.type ?: "any",
+					required : p.required ?: false
+				}) ) )
 
 				argumentDescriptions.each( ( argName, argDesc ) => tool.describeArg( argName, argDesc ) )
 				register( tool, targetModule, toolName )

--- a/src/main/bx/models/tools/ClosureTool.bx
+++ b/src/main/bx/models/tools/ClosureTool.bx
@@ -80,17 +80,6 @@ class extends="BaseTool" {
 	}
 
 	/**
-	 * Override the parameter list used for schema generation and invocation coercion.
-	 * Each element must be a struct with at least { name, type, required }.
-	 *
-	 * @params Array of parameter descriptor structs
-	 */
-	ClosureTool function setMethodParameters( required array params ) {
-		variables.methodParameters = arguments.params
-		return this
-	}
-
-	/**
 	 * Set the callable function this tool will invoke.
 	 *
 	 * @callable A closure, lambda, or function reference

--- a/src/main/bx/models/tools/ClosureTool.bx
+++ b/src/main/bx/models/tools/ClosureTool.bx
@@ -29,6 +29,13 @@ class extends="BaseTool" {
 	property name="callable";
 
 	/**
+	 * Explicit parameter descriptors that override callable introspection during schema generation.
+	 * Each entry: { name: "orderId", type: "string", required: true }
+	 * Set by AIToolRegistry.scanClass() so scanned methods expose their real params, not the wrapper lambda's.
+	 */
+	property name="methodParameters" default=[];
+
+	/**
 	 * Maps BoxLang parameter types to JSON Schema types for OpenAI function-calling schemas.
 	 * Modeled on SchemaBuilder.TYPE_MAP but kept local to avoid import coupling.
 	 */
@@ -73,6 +80,17 @@ class extends="BaseTool" {
 	}
 
 	/**
+	 * Override the parameter list used for schema generation and invocation coercion.
+	 * Each element must be a struct with at least { name, type, required }.
+	 *
+	 * @params Array of parameter descriptor structs
+	 */
+	ClosureTool function setMethodParameters( required array params ) {
+		variables.methodParameters = arguments.params
+		return this
+	}
+
+	/**
 	 * Set the callable function this tool will invoke.
 	 *
 	 * @callable A closure, lambda, or function reference
@@ -105,7 +123,8 @@ class extends="BaseTool" {
 		// object/array (e.g. JSON-encoded fields like source_context or key_decisions). Without
 		// this, BoxLang's typed-arg binding would throw "Can't cast Struct<Ordered> to a string" before the callable runs.
 		var incomingArgs = arguments.args
-		variables.callable.$bx.meta.parameters.each( param => {
+		var coercionParams = variables.methodParameters.len() ? variables.methodParameters : variables.callable.$bx.meta.parameters
+		coercionParams.each( param => {
 			if ( ( param.type ?: "" ) == "string" && incomingArgs.keyExists( param.name ) ) {
 				var value = incomingArgs[ param.name ]
 				if ( !isNull( value ) && !isSimpleValue( value ) ) {
@@ -154,8 +173,9 @@ class extends="BaseTool" {
 				message : "No callable has been set. Use call() before calling getArgumentsSchema()."
 			)
 		}
-		var results = { "properties" : {}, "required" : [] }
-		variables.callable.$bx.meta.parameters.each( param => {
+		var results    = { "properties" : {}, "required" : [] }
+		var paramList  = variables.methodParameters.len() ? variables.methodParameters : variables.callable.$bx.meta.parameters
+		paramList.each( param => {
 			if ( param.required ) {
 				results.required.append( param.name )
 			}

--- a/src/test/bx/tools/ScanTestTools.bx
+++ b/src/test/bx/tools/ScanTestTools.bx
@@ -1,0 +1,38 @@
+/**
+ * Test fixture: a class with @AITool-annotated methods.
+ * Used by AiToolRegistryTest to validate scanClass() schema generation.
+ */
+class {
+
+	/**
+	 * Retrieve a single order by order ID.
+	 *
+	 * @orderId The alphanumeric order ID, e.g. PD0002
+	 */
+	@AITool( "Retrieve a single order by order ID." )
+	public string function getOrder( required string orderId ) {
+		return arguments.orderId
+	}
+
+	/**
+	 * Search orders by keyword.
+	 *
+	 * @query Search keyword
+	 * @limit Max results to return
+	 */
+	@AITool( "Search orders by keyword." )
+	public string function searchOrders( required string query, numeric limit = 10 ) {
+		return "results for #arguments.query#"
+	}
+
+	/**
+	 * Echo a value back to the caller.
+	 *
+	 * @value The value to echo
+	 */
+	@AITool( "Echo a value back to the caller." )
+	public string function echo( required string value ) {
+		return arguments.value
+	}
+
+}

--- a/src/test/java/ortus/boxlang/ai/registry/AiToolRegistryTest.java
+++ b/src/test/java/ortus/boxlang/ai/registry/AiToolRegistryTest.java
@@ -258,6 +258,101 @@ public class AiToolRegistryTest extends BaseIntegrationTest {
 	}
 
 	// -------------------------------------------------------------------------
+	// scanClass() — schema correctness
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "scanClass() schema uses real parameter names, not 'args'" )
+	@Test
+	public void testScanClassSchemaHasRealParamNames() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg   = aiToolRegistry()
+				tools = reg.scanClass( createObject( "src.test.bx.tools.ScanTestTools" ) )
+				// getOrder is the first @AITool method
+				tool   = tools.filter( t => t.getName() == "getOrder" )[ 1 ]
+				schema = tool.generateSchema()
+				hasOrderId = schema.function.parameters.properties.keyExists( "orderId" )
+				hasArgs    = schema.function.parameters.properties.keyExists( "args" )
+				reg.unregister( "getOrder" )
+				reg.unregister( "searchOrders" )
+				reg.unregister( "echo" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "hasOrderId" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "hasArgs" ) ) ).isEqualTo( false );
+	}
+
+	@DisplayName( "scanClass() schema marks required parameters in the required array" )
+	@Test
+	public void testScanClassSchemaRequiredParams() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg    = aiToolRegistry()
+				tools  = reg.scanClass( createObject( "src.test.bx.tools.ScanTestTools" ) )
+				tool   = tools.filter( t => t.getName() == "searchOrders" )[ 1 ]
+				schema = tool.generateSchema()
+				required = schema.function.parameters.required
+				result   = required.contains( "query" ) && !required.contains( "limit" )
+				reg.unregister( "getOrder" )
+				reg.unregister( "searchOrders" )
+				reg.unregister( "echo" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
+	@DisplayName( "scanClass() schema carries parameter descriptions from @hint" )
+	@Test
+	public void testScanClassSchemaParamDescriptions() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg    = aiToolRegistry()
+				tools  = reg.scanClass( createObject( "src.test.bx.tools.ScanTestTools" ) )
+				tool   = tools.filter( t => t.getName() == "getOrder" )[ 1 ]
+				schema = tool.generateSchema()
+				result = schema.function.parameters.properties.orderId.description
+				reg.unregister( "getOrder" )
+				reg.unregister( "searchOrders" )
+				reg.unregister( "echo" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "The alphanumeric order ID, e.g. PD0002" );
+	}
+
+	@DisplayName( "scanClass() tool invocation forwards named arguments to the target method" )
+	@Test
+	public void testScanClassInvocationForwardsNamedArgs() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				reg    = aiToolRegistry()
+				tools  = reg.scanClass( createObject( "src.test.bx.tools.ScanTestTools" ) )
+				tool   = tools.filter( t => t.getName() == "echo" )[ 1 ]
+				result = tool.invoke( { value: "hello" } )
+				reg.unregister( "getOrder" )
+				reg.unregister( "searchOrders" )
+				reg.unregister( "echo" )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "hello" );
+	}
+
+	// -------------------------------------------------------------------------
 	// Singleton
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
# Description

Fixes a critical bug in `aiToolRegistry().scanClass()` where generated JSON schemas for scanned `@AITool` methods were exposing a generic `args` parameter instead of the actual method parameters (e.g., `orderId`, `query`). Additionally, the `required` array in the schema was always empty for scanned tools.

## Root Cause

When `scanClass()` wrapped annotated methods in a closure for invocation, the schema generation code introspected that wrapper lambda's signature (`(args) =>`) rather than the original method's signature. This caused:
1. Schema properties to show only `args` instead of real parameter names
2. Required parameters to not be marked in the `required` array
3. Invocation to fail when callers used the real parameter names from the schema

## Solution

- Added `methodParameters` property to `ClosureTool` to store original method parameter metadata (`name`, `type`, `required`)
- Added `setMethodParameters()` method to allow `AIToolRegistry.scanClass()` to inject the real parameter descriptors
- Updated `getArgumentsSchema()` and `invoke()` to use `methodParameters` when available, falling back to callable introspection
- Fixed the wrapper lambda in `scanClass()` to properly forward named arguments via the `arguments` scope instead of a generic `args` parameter

## Testing

Added comprehensive test suite in `AiToolRegistryTest`:
- `testScanClassSchemaHasRealParamNames()` — Verifies schema contains real parameter names, not `args`
- `testScanClassSchemaRequiredParams()` — Verifies required parameters are correctly marked
- `testScanClassSchemaParamDescriptions()` — Verifies parameter descriptions from `@hint` are preserved
- `testScanClassInvocationForwardsNamedArgs()` — Verifies tool invocation works with named arguments

Added test fixture `ScanTestTools.bx` with three `@AITool` methods demonstrating various parameter configurations.

## Jira/Github Issues

Please link the corresponding issue here.

## Type of change

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_014KuhPShJbtwF3LpFP5qVXH