### PR TITLE
Structured output for Claude on Bedrock & native Anthropic API via fo…

### DIFF
--- a/src/main/bx/models/providers/BedrockService.bx
+++ b/src/main/bx/models/providers/BedrockService.bx
@@ -32,6 +32,7 @@
  * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html
  */
 import bxModules.bxai.models.util.AwsSignatureV4;
+import bxModules.bxai.models.util.SchemaBuilder;
 import bxModules.bxai.models.providers.capabilities.IAiChatService;
 import bxModules.bxai.models.providers.capabilities.IAiEmbeddingsService;
 
@@ -73,6 +74,8 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 		};
 		// Bedrock service name for AWS signing
 		AWS_SERVICE = "bedrock";
+		// Synthetic tool name used to force Claude into structured-output mode on Bedrock
+		STRUCTURED_OUTPUT_TOOL = "structured_output";
 	}
 
 	/**
@@ -678,6 +681,35 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 	}
 
 	/**
+	 * Inject a forced structured-output tool into the Claude request packet.
+	 *
+	 * Exposes the request's structured-output schema as the synthetic tool's input_schema
+	 * and pins tool_choice to it, so Claude is guaranteed to return a single tool_use block
+	 * whose input conforms to the schema. Any real tools are left in place but will not be
+	 * called while tool_choice is forced.
+	 *
+	 * @dataPacket  The Claude request packet (mutated in place)
+	 * @chatRequest The request carrying the structured-output schema
+	 */
+	private void function injectStructuredOutputTool( required struct dataPacket, required AiChatRequest chatRequest ){
+		var cleanSchema = SchemaBuilder::cleanSchema( arguments.chatRequest.getStructuredOutput() );
+
+		if ( !arguments.dataPacket.keyExists( "tools" ) ) {
+			arguments.dataPacket[ "tools" ] = [];
+		}
+		arguments.dataPacket.tools.append( {
+			"name"        : static.STRUCTURED_OUTPUT_TOOL,
+			"description" : "Record the response as structured data that conforms to the required JSON schema.",
+			"input_schema": cleanSchema
+		} );
+
+		arguments.dataPacket[ "tool_choice" ] = {
+			"type" : "tool",
+			"name" : static.STRUCTURED_OUTPUT_TOOL
+		};
+	}
+
+	/**
 	 * Execute a Claude tool call returned by Bedrock and append the tool_result
 	 * message to the conversation.
 	 *
@@ -742,6 +774,17 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 			params      = arguments.chatRequest.getParams(),
 			modelFamily = modelFamily
 		);
+
+		// -------------------------------------------------------------------------------------------
+		// --- Structured output via forced tool-use (Claude models only) ---
+		// Claude on Bedrock has no response_format; the robust pattern is to expose the requested
+		// schema as a tool's input_schema and force the model to call it, then read tool_use.input.
+		// @see https://aws.amazon.com/blogs/machine-learning/structured-data-response-with-amazon-bedrock-prompt-engineering-and-tool-use/
+		// -------------------------------------------------------------------------------------------
+		var usingStructuredOutput = ( modelFamily == "claude" && arguments.chatRequest.isStructuredOutput() );
+		if ( usingStructuredOutput ) {
+			injectStructuredOutputTool( dataPacket, arguments.chatRequest );
+		}
 
 		// -------------------------------------------------------------------------------------------
 		// --- Fire beforeLLMCall middleware ---
@@ -814,6 +857,33 @@ class extends = "BaseService" implements="IAiChatService, IAiEmbeddingsService" 
 					usage               : openAIResponse.usage,
 					timestamp           : now()
 				}
+			);
+		}
+
+		// -------------------------------------------------------------------------------------------
+		// --- Structured output (Claude): the forced synthetic tool's input IS the result. ---
+		// Authoritative path — if the block is absent (truncated at max_tokens, a refusal, or
+		// tool_choice not honored) we fail loudly instead of feeding prose to the JSON populator.
+		// -------------------------------------------------------------------------------------------
+		if ( usingStructuredOutput ) {
+			// Local copy: lambdas don't capture the class `static` scope.
+			var toolName         = static.STRUCTURED_OUTPUT_TOOL;
+			var structuredBlocks = ( result.keyExists( "content" ) && isArray( result.content ) )
+				? result.content.filter( b => ( b?.type ?: "" ) == "tool_use" && ( b?.name ?: "" ) == toolName )
+				: [];
+			if ( structuredBlocks.len() ) {
+				return populateStructuredOutput( jsonSerialize( structuredBlocks.first().input ?: {} ), arguments.chatRequest );
+			}
+			var stopReason = result.stop_reason ?: "unknown";
+			writeLog(
+				text: "Structured output requested but no '#toolName#' tool_use block returned (model=#modelId#, stop_reason=#stopReason#)",
+				type: "error",
+				log : "ai"
+			);
+			throw(
+				type   : "StructuredOutputError",
+				message: "Model did not return the forced structured_output tool (stop_reason=#stopReason#)."
+					& ( stopReason == "max_tokens" ? " Response was truncated — increase max_tokens." : "" )
 			);
 		}
 

--- a/src/main/bx/models/providers/ClaudeService.bx
+++ b/src/main/bx/models/providers/ClaudeService.bx
@@ -14,6 +14,7 @@
  * ----------------------------------------------------------------------------------
  */
 import bxModules.bxai.models.providers.capabilities.IAiChatService;
+import bxModules.bxai.models.util.SchemaBuilder;
 
 class extends="BaseService" implements="IAiChatService" {
 
@@ -32,6 +33,8 @@ class extends="BaseService" implements="IAiChatService" {
 			// https://docs.anthropic.com/en/api/versioning
 			"anthropic-version" : "2023-06-01"
 		};
+		// Synthetic tool name used to force Claude into structured-output mode
+		STRUCTURED_OUTPUT_TOOL = "structured_output";
 	}
 
 	/**
@@ -448,6 +451,17 @@ class extends="BaseService" implements="IAiChatService" {
 		}
 
 		// -------------------------------------------------------------------------------------------
+		// --- Structured output via forced tool-use ---
+		// The Anthropic Messages API has no response_format; the robust pattern is to expose the
+		// requested schema as a tool's input_schema and force the model to call it, then read
+		// tool_use.input. https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+		// -------------------------------------------------------------------------------------------
+		var usingStructuredOutput = arguments.chatRequest.isStructuredOutput();
+		if( usingStructuredOutput ){
+			injectStructuredOutputTool( dataPacket, arguments.chatRequest );
+		}
+
+		// -------------------------------------------------------------------------------------------
 		// --- Fire beforeLLMCall middleware ---
 		// -------------------------------------------------------------------------------------------
 		var llmContext = { chatRequest: arguments.chatRequest, dataPacket: dataPacket }
@@ -502,6 +516,31 @@ class extends="BaseService" implements="IAiChatService" {
 				timestamp        : now()
 			} )
 		}
+		// Structured output: the forced synthetic tool's input IS the result. Authoritative path —
+		// if the block is absent (truncated at max_tokens, a refusal, or tool_choice not honored)
+		// we fail loudly instead of feeding prose to the JSON populator.
+		if( usingStructuredOutput ){
+			// Local copy: lambdas don't capture the class `static` scope.
+			var toolName         = static.STRUCTURED_OUTPUT_TOOL;
+			var structuredBlocks = ( result.keyExists( "content" ) && isArray( result.content ) )
+				? result.content.filter( b => ( b?.type ?: "" ) == "tool_use" && ( b?.name ?: "" ) == toolName )
+				: [];
+			if( structuredBlocks.len() ){
+				return populateStructuredOutput( jsonSerialize( structuredBlocks.first().input ?: {} ), arguments.chatRequest );
+			}
+			var stopReason = result.stop_reason ?: "unknown";
+			writeLog(
+				text: "Structured output requested but no '#toolName#' tool_use block returned (model=#arguments.chatRequest.getModel()#, stop_reason=#stopReason#)",
+				type: "error",
+				log : "ai"
+			)
+			throw(
+				type   : "StructuredOutputError",
+				message: "Model did not return the forced structured_output tool (stop_reason=#stopReason#)."
+					& ( stopReason == "max_tokens" ? " Response was truncated — increase max_tokens." : "" )
+			);
+		}
+
 		// Handle tool use responses
 		// Check if Claude wants to use tools
 		var usingTools = false
@@ -566,6 +605,35 @@ class extends="BaseService" implements="IAiChatService" {
 			case "single": default:
 				return content;
 		}
+	}
+
+	/**
+	 * Inject a forced structured-output tool into the Claude request packet.
+	 *
+	 * Exposes the request's structured-output schema as the synthetic tool's input_schema
+	 * and pins tool_choice to it, so Claude is guaranteed to return a single tool_use block
+	 * whose input conforms to the schema. Any real tools are left in place but will not be
+	 * called while tool_choice is forced.
+	 *
+	 * @dataPacket  The Claude request packet (mutated in place)
+	 * @chatRequest The request carrying the structured-output schema
+	 */
+	private void function injectStructuredOutputTool( required struct dataPacket, required AiChatRequest chatRequest ){
+		var cleanSchema = SchemaBuilder::cleanSchema( arguments.chatRequest.getStructuredOutput() );
+
+		if( !arguments.dataPacket.keyExists( "tools" ) ){
+			arguments.dataPacket[ "tools" ] = [];
+		}
+		arguments.dataPacket.tools.append( {
+			"name"        : static.STRUCTURED_OUTPUT_TOOL,
+			"description" : "Record the response as structured data that conforms to the required JSON schema.",
+			"input_schema": cleanSchema
+		} );
+
+		arguments.dataPacket[ "tool_choice" ] = {
+			"type" : "tool",
+			"name" : static.STRUCTURED_OUTPUT_TOOL
+		};
 	}
 
 	/**

--- a/src/test/java/ortus/boxlang/ai/providers/BedrockServiceTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/BedrockServiceTest.java
@@ -193,6 +193,176 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 	}
 
 	@Test
+	@DisplayName( "Structured output forces a tool-use schema for Claude on Bedrock" )
+	public void testStructuredOutputInjectsForcedTool() {
+		// Deterministic / credential-free: a beforeLLMCall middleware captures the request
+		// packet and short-circuits before any signing or HTTP call, so we can assert the
+		// forced structured_output tool + tool_choice were injected.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+				captured = {}
+				provider = aiService(
+					"bedrock",
+					{
+						awsAccessKeyId: "%s",
+						awsSecretAccessKey: "%s",
+						region: "%s"
+					}
+				)
+
+				chatRequest = aiChatRequest(
+					aiMessage().user( "Extract the person: John Doe, age 30" ),
+					{ model: "anthropic.claude-3-sonnet-20240229-v1:0", max_tokens: 200 },
+					{
+						provider: "bedrock",
+						schema: {
+							"type": "object",
+							"properties": {
+								"name": { "type": "string" },
+								"age":  { "type": "integer" }
+							},
+							"required": [ "name", "age" ]
+						}
+					}
+				)
+
+				chatRequest.addMiddleware( {
+					"beforeLLMCall": ( ctx ) => {
+						captured.packet = ctx.dataPacket
+						return new src.main.bx.models.middleware.AiMiddlewareResult( "cancel", "test-capture" )
+					}
+				} )
+
+				provider.chat( chatRequest )
+
+				hasTools       = captured.packet.keyExists( "tools" )
+				toolCount      = captured.packet.tools.len()
+				toolName       = captured.packet.tools[ 1 ].name
+				hasInputSchema = captured.packet.tools[ 1 ].keyExists( "input_schema" )
+				hasNameProp    = captured.packet.tools[ 1 ].input_schema.properties.keyExists( "name" )
+				hasToolChoice  = captured.packet.keyExists( "tool_choice" )
+				choiceType     = captured.packet.tool_choice.type
+				choiceName     = captured.packet.tool_choice.name
+			""".formatted( DUMMY_AWS_ACCESS_KEY_ID, DUMMY_AWS_SECRET_ACCESS_KEY, DUMMY_AWS_REGION ),
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "hasTools" ) ) ).isTrue();
+		assertThat( variables.getAsInteger( Key.of( "toolCount" ) ) ).isEqualTo( 1 );
+		assertThat( variables.get( Key.of( "toolName" ) ) ).isEqualTo( "structured_output" );
+		assertThat( variables.getAsBoolean( Key.of( "hasInputSchema" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "hasNameProp" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "hasToolChoice" ) ) ).isTrue();
+		assertThat( variables.get( Key.of( "choiceType" ) ) ).isEqualTo( "tool" );
+		assertThat( variables.get( Key.of( "choiceName" ) ) ).isEqualTo( "structured_output" );
+	}
+
+	@Test
+	@DisplayName( "Structured output extracts the forced tool_use input (canned response)" )
+	public void testStructuredOutputExtractsFromToolUse() {
+		// Deterministic: a wrapLLMCall middleware returns a canned Bedrock Claude response
+		// containing the forced structured_output tool_use block, exercising the extraction
+		// + populateStructuredOutput path with no HTTP.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+				provider = aiService(
+					"bedrock",
+					{ awsAccessKeyId: "%s", awsSecretAccessKey: "%s", region: "%s" }
+				)
+				chatRequest = aiChatRequest(
+					aiMessage().user( "Extract: John Doe, age 30" ),
+					{ model: "anthropic.claude-3-sonnet-20240229-v1:0" },
+					{
+						provider: "bedrock",
+						schema: {
+							"type": "object",
+							"properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+							"required": [ "name", "age" ]
+						}
+					}
+				)
+				chatRequest.addMiddleware( {
+					"wrapLLMCall": ( ctx, handler ) => {
+						return {
+							"content": [ {
+								"type":  "tool_use",
+								"name":  "structured_output",
+								"input": { "name": "John Doe", "age": 30 }
+							} ],
+							"stop_reason": "tool_use",
+							"usage": { "input_tokens": 5, "output_tokens": 8 }
+						}
+					}
+				} )
+				result   = provider.chat( chatRequest )
+				isStruct = isStruct( result )
+				name     = result.name
+				age      = result.age
+			""".formatted( DUMMY_AWS_ACCESS_KEY_ID, DUMMY_AWS_SECRET_ACCESS_KEY, DUMMY_AWS_REGION ),
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "isStruct" ) ) ).isTrue();
+		assertThat( variables.get( Key.of( "name" ) ).toString() ).isEqualTo( "John Doe" );
+		assertThat( variables.getAsInteger( Key.of( "age" ) ) ).isEqualTo( 30 );
+	}
+
+	@Test
+	@DisplayName( "Structured output throws (not silent) when the forced tool block is absent" )
+	public void testStructuredOutputThrowsWhenToolAbsent() {
+		// Deterministic: canned response is a text block (e.g. truncated at max_tokens), so the
+		// forced structured_output block is missing. Must throw StructuredOutputError, not feed
+		// prose into the JSON populator.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+				provider = aiService(
+					"bedrock",
+					{ awsAccessKeyId: "%s", awsSecretAccessKey: "%s", region: "%s" }
+				)
+				chatRequest = aiChatRequest(
+					aiMessage().user( "Extract: John Doe, age 30" ),
+					{ model: "anthropic.claude-3-sonnet-20240229-v1:0" },
+					{
+						provider: "bedrock",
+						schema: {
+							"type": "object",
+							"properties": { "name": { "type": "string" } },
+							"required": [ "name" ]
+						}
+					}
+				)
+				chatRequest.addMiddleware( {
+					"wrapLLMCall": ( ctx, handler ) => {
+						return {
+							"content": [ { "type": "text", "text": "I cannot comply." } ],
+							"stop_reason": "max_tokens",
+							"usage": { "input_tokens": 5, "output_tokens": 3 }
+						}
+					}
+				} )
+				caughtType = ""
+				caughtMsg  = ""
+				try {
+					provider.chat( chatRequest )
+				} catch( any e ) {
+					caughtType = e.type
+					caughtMsg  = e.message
+				}
+			""".formatted( DUMMY_AWS_ACCESS_KEY_ID, DUMMY_AWS_SECRET_ACCESS_KEY, DUMMY_AWS_REGION ),
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "caughtType" ) ) ).isEqualTo( "StructuredOutputError" );
+		assertThat( variables.get( Key.of( "caughtMsg" ) ).toString() ).contains( "truncated" );
+	}
+
+	@Test
 	@DisplayName( "AiChatRequest supports providerOptions for provider-specific settings" )
 	public void testProviderOptions() {
 		// @formatter:off

--- a/src/test/java/ortus/boxlang/ai/providers/BedrockTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/BedrockTest.java
@@ -39,7 +39,9 @@ import ortus.boxlang.runtime.types.Struct;
  */
 public class BedrockTest extends BaseIntegrationTest {
 
-	private static final String	BEDROCK_MODEL	= "anthropic.claude-3-5-sonnet-20240620-v1:0";
+	private static final String	BEDROCK_MODEL				= "anthropic.claude-3-5-sonnet-20240620-v1:0";
+	// Cross-region inference profile id reachable in eu-west-2 for structured-output coverage
+	private static final String	BEDROCK_STRUCTURED_MODEL	= "eu.anthropic.claude-sonnet-4-6";
 
 	private String				awsAccessKeyId;
 	private String				awsSecretAccessKey;
@@ -130,6 +132,49 @@ public class BedrockTest extends BaseIntegrationTest {
 		// @formatter:on
 
 		assertThat( variables.get( Key.of( "result" ) ) ).isEqualTo( "San Salvador" );
+	}
+
+	@DisplayName( "Test Bedrock structured output via forced tool-use" )
+	@Test
+	public void testBedrockStructuredOutput() {
+		if ( !hasAwsCredentials() ) {
+			System.out.println( "Skipping testBedrockStructuredOutput - AWS credentials not configured in .env" );
+			return;
+		}
+
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+			result = aiChat(
+				messages = "John Doe is 30 years old and lives in Seattle. Extract his details.",
+				params   = { model: "%s", max_tokens: 300 },
+				options  = {
+					provider: "bedrock",
+					schema: {
+						"type": "object",
+						"properties": {
+							"name": { "type": "string" },
+							"age":  { "type": "integer" },
+							"city": { "type": "string" }
+						},
+						"required": [ "name", "age", "city" ]
+					}
+				}
+			)
+			isStruct = isStruct( result )
+			name = result.name ?: ""
+			age  = result.age  ?: 0
+			city = result.city ?: ""
+			println( result )
+			""".formatted( BEDROCK_STRUCTURED_MODEL ),
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "isStruct" ) ) ).isTrue();
+		assertThat( variables.get( Key.of( "name" ) ).toString() ).contains( "John" );
+		assertThat( variables.getAsInteger( Key.of( "age" ) ) ).isEqualTo( 30 );
+		assertThat( variables.get( Key.of( "city" ) ).toString() ).contains( "Seattle" );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/ai/providers/ClaudeTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/ClaudeTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.ai.BaseIntegrationTest;
+import ortus.boxlang.runtime.scopes.Key;
 
 /**
  * Integration tests for Claude AI provider
@@ -166,6 +167,162 @@ public class ClaudeTest extends BaseIntegrationTest {
 		var result = ( ortus.boxlang.runtime.types.IStruct ) variables.get( "result" );
 		assertThat( result.containsKey( "name" ) || result.containsKey( "NAME" ) ).isTrue();
 		assertThat( result.containsKey( "version" ) || result.containsKey( "VERSION" ) ).isTrue();
+	}
+
+	@DisplayName( "Structured output forces a tool-use schema for Claude" )
+	@Test
+	public void testStructuredOutputInjectsForcedTool() {
+		// Deterministic / credential-free: a beforeLLMCall middleware captures the request
+		// packet and short-circuits before any HTTP call, so we can assert the forced
+		// structured_output tool + tool_choice were injected.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+				captured = {}
+				provider = aiService( "claude", { apiKey: "dummy-key" } )
+
+				chatRequest = aiChatRequest(
+					aiMessage().user( "Extract the person: John Doe, age 30" ),
+					{ model: "claude-sonnet-4-5", max_tokens: 200 },
+					{
+						provider: "claude",
+						schema: {
+							"type": "object",
+							"properties": {
+								"name": { "type": "string" },
+								"age":  { "type": "integer" }
+							},
+							"required": [ "name", "age" ]
+						}
+					}
+				)
+
+				chatRequest.addMiddleware( {
+					"beforeLLMCall": ( ctx ) => {
+						captured.packet = ctx.dataPacket
+						return new src.main.bx.models.middleware.AiMiddlewareResult( "cancel", "test-capture" )
+					}
+				} )
+
+				provider.chat( chatRequest )
+
+				hasTools       = captured.packet.keyExists( "tools" )
+				toolCount      = captured.packet.tools.len()
+				toolName       = captured.packet.tools[ 1 ].name
+				hasInputSchema = captured.packet.tools[ 1 ].keyExists( "input_schema" )
+				hasNameProp    = captured.packet.tools[ 1 ].input_schema.properties.keyExists( "name" )
+				hasToolChoice  = captured.packet.keyExists( "tool_choice" )
+				choiceType     = captured.packet.tool_choice.type
+				choiceName     = captured.packet.tool_choice.name
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "hasTools" ) ) ).isTrue();
+		assertThat( variables.getAsInteger( Key.of( "toolCount" ) ) ).isEqualTo( 1 );
+		assertThat( variables.get( Key.of( "toolName" ) ) ).isEqualTo( "structured_output" );
+		assertThat( variables.getAsBoolean( Key.of( "hasInputSchema" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "hasNameProp" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "hasToolChoice" ) ) ).isTrue();
+		assertThat( variables.get( Key.of( "choiceType" ) ) ).isEqualTo( "tool" );
+		assertThat( variables.get( Key.of( "choiceName" ) ) ).isEqualTo( "structured_output" );
+	}
+
+	@DisplayName( "Structured output extracts the forced tool_use input (canned response)" )
+	@Test
+	public void testStructuredOutputExtractsFromToolUse() {
+		// Deterministic: a wrapLLMCall middleware returns a canned Anthropic response containing
+		// the forced structured_output tool_use block, exercising the extraction +
+		// populateStructuredOutput path with no HTTP.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+				provider = aiService( "claude", { apiKey: "dummy-key" } )
+				chatRequest = aiChatRequest(
+					aiMessage().user( "Extract: John Doe, age 30" ),
+					{ model: "claude-sonnet-4-5" },
+					{
+						provider: "claude",
+						schema: {
+							"type": "object",
+							"properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+							"required": [ "name", "age" ]
+						}
+					}
+				)
+				chatRequest.addMiddleware( {
+					"wrapLLMCall": ( ctx, handler ) => {
+						return {
+							"content": [ {
+								"type":  "tool_use",
+								"name":  "structured_output",
+								"input": { "name": "John Doe", "age": 30 }
+							} ],
+							"stop_reason": "tool_use",
+							"usage": { "input_tokens": 5, "output_tokens": 8 }
+						}
+					}
+				} )
+				result   = provider.chat( chatRequest )
+				isStruct = isStruct( result )
+				name     = result.name
+				age      = result.age
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "isStruct" ) ) ).isTrue();
+		assertThat( variables.get( Key.of( "name" ) ).toString() ).isEqualTo( "John Doe" );
+		assertThat( variables.getAsInteger( Key.of( "age" ) ) ).isEqualTo( 30 );
+	}
+
+	@DisplayName( "Structured output throws (not silent) when the forced tool block is absent" )
+	@Test
+	public void testStructuredOutputThrowsWhenToolAbsent() {
+		// Deterministic: canned response is a text block (e.g. truncated at max_tokens), so the
+		// forced structured_output block is missing. Must throw StructuredOutputError.
+		// @formatter:off
+		executeWithTimeoutHandling(
+			"""
+				provider = aiService( "claude", { apiKey: "dummy-key" } )
+				chatRequest = aiChatRequest(
+					aiMessage().user( "Extract: John Doe, age 30" ),
+					{ model: "claude-sonnet-4-5" },
+					{
+						provider: "claude",
+						schema: {
+							"type": "object",
+							"properties": { "name": { "type": "string" } },
+							"required": [ "name" ]
+						}
+					}
+				)
+				chatRequest.addMiddleware( {
+					"wrapLLMCall": ( ctx, handler ) => {
+						return {
+							"content": [ { "type": "text", "text": "I cannot comply." } ],
+							"stop_reason": "max_tokens",
+							"usage": { "input_tokens": 5, "output_tokens": 3 }
+						}
+					}
+				} )
+				caughtType = ""
+				caughtMsg  = ""
+				try {
+					provider.chat( chatRequest )
+				} catch( any e ) {
+					caughtType = e.type
+					caughtMsg  = e.message
+				}
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.get( Key.of( "caughtType" ) ) ).isEqualTo( "StructuredOutputError" );
+		assertThat( variables.get( Key.of( "caughtMsg" ) ).toString() ).contains( "truncated" );
 	}
 
 	@DisplayName( "Test streaming chat with Claude" )


### PR DESCRIPTION
## Summary

Adds structured-data-response support for Anthropic **Claude on AWS Bedrock** and the **native Anthropic Messages API**. Previously structured output worked for OpenAI/Ollama/Cohere (via `response_format`/`format`) but was silently unsupported for Claude — the schema was never sent, so Claude returned prose and `populateStructuredOutput()` threw an opaque JSON-parse error.

Ticket: ortus-boxlang/bx-ai#198 — https://github.com/ortus-boxlang/bx-ai/issues/198

## What changed

Uses Anthropic's recommended **forced tool-use** pattern in both `BedrockService` and `ClaudeService`:

1. When `isStructuredOutput()` is true for a Claude model, inject a synthetic `structured_output` tool whose `input_schema` is the requested JSON schema (`SchemaBuilder::cleanSchema`) and pin `tool_choice` to it.
2. On response, extract the returned `tool_use` block named `structured_output` and route its `.input` through the existing `populateStructuredOutput()` (reuses class/struct/array population incl. the `{items:[...]}` unwrap).
3. **Fail loud, not silent**: if no `structured_output` block comes back (truncated at `max_tokens`, a refusal, or `tool_choice` not honored), `writeLog` to the `ai` log and `throw StructuredOutputError` (with `stop_reason`) instead of feeding prose into the JSON populator.

No public API change — `schema()` / `structuredOutput()` are unchanged.

## Tests

- **Deterministic, credential-free** (both providers):
  - `beforeLLMCall` middleware captures the request packet → asserts the forced `structured_output` tool + `tool_choice`.
  - `wrapLLMCall` middleware returns a canned `tool_use` response → asserts extraction into a populated struct, and asserts the fail-loud `StructuredOutputError` when the tool block is absent.
- **Live** Bedrock structured-output test gated on AWS creds (`eu.anthropic.claude-sonnet-4-6`).

## Verification

Verified end-to-end against live Bedrock and in a running app — flight-recorder shows Claude returning `{"type":"tool_use","name":"structured_output","input":{...}}` / `stop_reason: tool_use`, populated correctly with no JSON-parse errors.

## Notes

- BoxLang `->` is a lambda (no enclosing-scope capture); the response filter uses `=>` to reference the tool-name local.
- `STRUCTURED_OUTPUT_TOOL` is a per-provider `static` constant (no magic strings).