### PR TITLE
fix(SummaryMemory): give maxMessages and summaryThreshold distinct roles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🧠 Updated
 
+- **SummaryMemory trigger fix — `maxMessages` and `summaryThreshold` now have distinct, non-overlapping roles**: Previously `summaryThreshold` was used for both the auto-trigger and the keep-window, making `maxMessages` dead weight that was stored and exported but never consulted. Now: `maxMessages` is the **trigger** (compression fires when non-system message count reaches this value) and `summaryThreshold` is the **keep-window** (how many recent messages survive verbatim after compression). Result after compression: `[system?] + [AI summary] + [last summaryThreshold messages]`. A validation guard throws `InvalidConfiguration` if `summaryThreshold >= maxMessages`. Default values (maxMessages=20, summaryThreshold=10) are unchanged.
+
 - **Template-confusion hardening (on by default)**: `AiMessage` now escapes `${...}` inside binding VALUES (via `PromptSecurity::escapeBindings`) before `stringBind`, so untrusted data can't be mistaken for a template placeholder. This is defense-in-depth — `stringBind` does not recurse today (verified by test), so no active re-interpolation vulnerability existed — and only changes output for values that literally contain `${`. Disable per message with `aiMessage().setEscapeBindings( false )` or globally via `security.fencing.escapeBindings = false`; internal/`secure:false` requests are exempt. Default `AiMessage.render()` output is otherwise byte-identical (backwards compatible).
 
 - **Security & Guardrails suite (Phase 1) — prompt-injection defense**:

--- a/readme.md
+++ b/readme.md
@@ -334,6 +334,32 @@ var result = agent.run( "What are the latest trends in AI?" )
 
 ### 🧠 Memory & RAG Pipelines
 
+#### Summary Memory (Auto-Compression)
+
+Summary Memory automatically compresses older messages into an AI-generated summary when the
+conversation buffer fills up, keeping the most recent messages verbatim for sharp context.
+
+| Parameter | Role | Default |
+|---|---|---|
+| `maxMessages` | **Trigger** — compress when non-system message count reaches this | `20` |
+| `summaryThreshold` | **Keep-window** — messages kept verbatim after compression | `10` |
+| `summaryModel` | AI model used to generate the summary | `"gpt-4o-mini"` |
+| `summaryProvider` | AI provider for summarization | `"openai"` |
+
+> **Constraint:** `summaryThreshold` must be less than `maxMessages` — otherwise compression
+> would re-trigger immediately on the next message.
+
+Result after compression: `[system?] + [AI summary] + [last summaryThreshold messages]`
+
+```javascript
+var memory = aiMemory( "summary", config: {
+    maxMessages      : 20,   // compress when buffer reaches 20 messages
+    summaryThreshold : 10,   // keep last 10 verbatim after each compression
+    summaryModel     : "gpt-4o-mini",
+    summaryProvider  : "openai"
+} )
+```
+
 ```javascript
 // Load documents into vector memory for semantic search
 var loader = aiDocuments( "pdf", "./docs/*.pdf" )

--- a/src/main/bx/models/memory/SummaryMemory.bx
+++ b/src/main/bx/models/memory/SummaryMemory.bx
@@ -107,7 +107,7 @@ class extends="WindowMemory" {
 	 * @return IAiMemory for chaining
 	 */
 	public IAiMemory function trim( string userId = "", string conversationId = "" ) {
-		if ( getNonSystemMessages().len() < variables.maxMessages ) {
+		if ( variables.maxMessages == 0 || getNonSystemMessages().len() < variables.maxMessages ) {
 			return this
 		}
 		this.summarize()

--- a/src/main/bx/models/memory/SummaryMemory.bx
+++ b/src/main/bx/models/memory/SummaryMemory.bx
@@ -13,13 +13,17 @@
  * governing permissions and limitations under the License.
  * ----------------------------------------------------------------------------------
  * Summary Memory - Intelligent conversation compression
- * Automatically summarizes older messages when limit reached
- * Keeps: [System Message] + [Summary of Old Messages] + [Recent Messages]
- * Perfect for long conversations where context must be preserved
+ * Automatically summarizes older messages when the buffer reaches maxMessages,
+ * then keeps the most recent summaryThreshold messages verbatim.
+ * Result: [System Message?] + [AI Summary] + [Last summaryThreshold Messages]
+ *
+ * Parameters:
+ *   maxMessages      — TRIGGER: compress when non-system message count reaches this (default: 20)
+ *   summaryThreshold — KEEP-WINDOW: messages kept verbatim after compression (default: 10)
+ *                      Must be less than maxMessages.
  *
  * The summarization logic lives in BaseMemory.summarize().
- * This class adds the auto-trigger behavior: when enough messages accumulate,
- * trim() automatically calls summarize() to keep memory within bounds.
+ * This class adds the auto-trigger in trim(), which fires on every add().
  */
 class extends="WindowMemory" {
 
@@ -33,13 +37,13 @@ class extends="WindowMemory" {
 	/**
 	 * Constructor
 	 *
-	 * @key The unique key for this memory instance
-	 * @userId The user identifier for multi-tenant isolation
-	 * @conversationId The conversation identifier for multiple conversations
-	 * @maxMessages Maximum total messages (default: 20)
-	 * @summaryThreshold Number of recent messages to keep (default: 10)
-	 * @summaryModel Model for summarization (default: gpt-4o-mini)
-	 * @summaryProvider Provider for summarization (default: openai)
+	 * @key              The unique key for this memory instance
+	 * @userId           The user identifier for multi-tenant isolation
+	 * @conversationId   The conversation identifier for multiple conversations
+	 * @maxMessages      Trigger: compress when non-system messages reach this count (default: 20)
+	 * @summaryThreshold Keep-window: messages kept verbatim after compression (default: 10). Must be < maxMessages.
+	 * @summaryModel     Model for summarization (default: gpt-4o-mini)
+	 * @summaryProvider  Provider for summarization (default: openai)
 	 */
 	function init(
 		string key = createUUID(),
@@ -59,6 +63,12 @@ class extends="WindowMemory" {
 			summaryModel: arguments.summaryModel,
 			summaryProvider: arguments.summaryProvider
 		)
+		if ( variables.summaryThreshold >= variables.maxMessages ) {
+			throw(
+				type: "InvalidConfiguration",
+				message: "SummaryMemory: summaryThreshold (#variables.summaryThreshold#) must be less than maxMessages (#variables.maxMessages#). summaryThreshold is the keep-window after compression; maxMessages is the trigger."
+			)
+		}
 		return this
 	}
 
@@ -73,14 +83,23 @@ class extends="WindowMemory" {
 	IAiMemory function configure( required struct config ) {
 		// BaseMemory.configure() handles all summary config wiring + model building
 		super.configure( arguments.config )
+		if ( variables.summaryThreshold >= variables.maxMessages ) {
+			throw(
+				type: "InvalidConfiguration",
+				message: "SummaryMemory: summaryThreshold (#variables.summaryThreshold#) must be less than maxMessages (#variables.maxMessages#). summaryThreshold is the keep-window after compression; maxMessages is the trigger."
+			)
+		}
 		return this
 	}
 
 	/**
-	 * Trim messages to keep only the last N (excluding system message)
-	 * Overrides base to add auto-summarization behavior.
-	 * When enough messages accumulate beyond the threshold, triggers summarize()
-	 * instead of simple truncation.
+	 * Auto-trigger summarization when the buffer reaches maxMessages.
+	 *
+	 * Roles:
+	 *   maxMessages      — trigger: fires when non-system message count reaches this value
+	 *   summaryThreshold — keep-window: how many recent messages survive verbatim (must be < maxMessages)
+	 *
+	 * Result after compression: [system?] + [AI summary] + [last summaryThreshold messages]
 	 *
 	 * @userId   Optional per-call user identifier (ignored — SummaryMemory is an on-object store)
 	 * @conversationId Optional per-call conversation identifier (ignored — SummaryMemory is an on-object store)
@@ -88,21 +107,10 @@ class extends="WindowMemory" {
 	 * @return IAiMemory for chaining
 	 */
 	public IAiMemory function trim( string userId = "", string conversationId = "" ) {
-		var nonSystemMessages = getNonSystemMessages()
-
-		// Calculate how many messages we would summarize
-		var totalMessages = nonSystemMessages.len()
-		var messagesToSummarize = totalMessages - variables.summaryThreshold
-
-		// Only summarize if we have accumulated at least threshold worth of messages
-		// This batches summarization and makes it more efficient
-		if ( messagesToSummarize < variables.summaryThreshold ) {
+		if ( getNonSystemMessages().len() < variables.maxMessages ) {
 			return this
 		}
-
-		// We have enough messages to summarize — delegate to base summarize()
 		this.summarize()
-
 		return this
 	}
 

--- a/src/main/bx/models/memory/SummaryMemory.bx
+++ b/src/main/bx/models/memory/SummaryMemory.bx
@@ -63,7 +63,7 @@ class extends="WindowMemory" {
 			summaryModel: arguments.summaryModel,
 			summaryProvider: arguments.summaryProvider
 		)
-		if ( variables.summaryThreshold >= variables.maxMessages ) {
+		if ( variables.maxMessages > 0 && variables.summaryThreshold >= variables.maxMessages ) {
 			throw(
 				type: "InvalidConfiguration",
 				message: "SummaryMemory: summaryThreshold (#variables.summaryThreshold#) must be less than maxMessages (#variables.maxMessages#). summaryThreshold is the keep-window after compression; maxMessages is the trigger."

--- a/src/test/java/ortus/boxlang/ai/memory/SummaryMemoryTest.java
+++ b/src/test/java/ortus/boxlang/ai/memory/SummaryMemoryTest.java
@@ -370,6 +370,53 @@ public class SummaryMemoryTest extends BaseIntegrationTest {
 	}
 
 	@Test
+	@DisplayName( "Test trigger fires at maxMessages, not 2×summaryThreshold" )
+	public void testTriggerAtMaxMessages() {
+		// maxMessages=10, summaryThreshold=4 → old broken trigger=8 (2×4), correct trigger=10
+		runtime.executeSource(
+		    """
+		    memory = aiMemory( memory: "summary", key: "trigger-test", config: {
+		        maxMessages: 10,
+		        summaryThreshold: 4
+		    } )
+
+		    // Add 9 messages — below maxMessages=10, so NO summarization should fire
+		    for( i = 1; i <= 9; i++ ) {
+		        memory.add( "Message " & i )
+		    }
+
+		    count = memory.count()
+		    hasSummary = memory.getHasSummary()
+		    """,
+		    context
+		);
+
+		// 9 < maxMessages(10) → no summarization yet
+		assertThat( variables.getAsInteger( Key.of( "count" ) ) ).isEqualTo( 9 );
+		assertThat( variables.getAsBoolean( Key.of( "hasSummary" ) ) ).isFalse();
+	}
+
+	@Test
+	@DisplayName( "Test summaryThreshold >= maxMessages throws InvalidConfiguration" )
+	public void testInvalidThresholdConfiguration() {
+		try {
+			runtime.executeSource(
+			    """
+			    memory = aiMemory( memory: "summary", config: {
+			        maxMessages: 5,
+			        summaryThreshold: 5
+			    } )
+			    """,
+			    context
+			);
+			// Should have thrown
+			assertThat( false ).isTrue();
+		} catch ( Exception e ) {
+			assertThat( e.getMessage() ).containsIgnoringCase( "summaryThreshold" );
+		}
+	}
+
+	@Test
 	@DisplayName( "Test SummaryMemory progressive summarization" )
 	public void testProgressiveSummarization() {
 		runtime.executeSource(

--- a/src/test/java/ortus/boxlang/ai/memory/SummaryMemoryTest.java
+++ b/src/test/java/ortus/boxlang/ai/memory/SummaryMemoryTest.java
@@ -412,7 +412,7 @@ public class SummaryMemoryTest extends BaseIntegrationTest {
 			// Should have thrown
 			assertThat( false ).isTrue();
 		} catch ( Exception e ) {
-			assertThat( e.getMessage() ).containsIgnoringCase( "summaryThreshold" );
+			assertThat( e.getMessage() ).contains( "summaryThreshold" );
 		}
 	}
 


### PR DESCRIPTION
Previously summaryThreshold drove both the auto-trigger (at 2×threshold)
and the keep-window, making maxMessages dead weight — stored and exported
but never consulted in trim().

Now:
  - maxMessages      = TRIGGER: compress when non-system messages reach this count
  - summaryThreshold = KEEP-WINDOW: messages kept verbatim after compression (must be < maxMessages)

Result after compression: [system?] + [AI summary] + [last summaryThreshold messages]

A validation guard in init() and configure() throws InvalidConfiguration
if summaryThreshold >= maxMessages. Default values (maxMessages=20,
summaryThreshold=10) are unchanged and satisfy the constraint.

Docs updated in class header, constructor, trim() comment, readme.md,
and changelog.md. Two new tests cover the correct trigger point and
the invalid-configuration guard.

Co-Authored-By: Claude <noreply@anthropic.com>