### PR TITLE
HITL: add durable pending-interaction index

### DIFF
--- a/src/main/bx/models/hitl/HumanInteractionCoordinator.bx
+++ b/src/main/bx/models/hitl/HumanInteractionCoordinator.bx
@@ -60,6 +60,20 @@
  * would never appear in getAllPending() at all. Treat that as out of scope for this phase,
  * same as the cross-process atomicity gap above.
  *
+ * Sharper version of that same caveat, worth knowing before choosing a checkpointer: the
+ * pending index is scoped ONLY by its fixed key, not by anything identifying this
+ * coordinator/agent — so two coordinators that happen to share a checkpointer resolving to
+ * the SAME underlying store see one COMBINED index, not two separate ones. In the common
+ * one-agent-per-checkpointer usage this never comes up. It's easy to hit by accident,
+ * though: CacheMemory's saveState/loadState/clearState key purely by threadId
+ * ("checkpoint:" & threadId, see CacheMemory.buildCheckpointKey()) — NOT by that
+ * CacheMemory instance's own `key` — so every `aiMemory("cache")` call anywhere in the
+ * same runtime shares one checkpoint keyspace regardless of how many separate instances
+ * you construct. Suspension-scoped keys (persistenceKey(), keyed by a UUID) don't collide
+ * in practice even when that keyspace is shared; this one fixed index key does. Give each
+ * logically-distinct coordinator/agent a genuinely isolated store (e.g. a File-backed
+ * memory pointed at its own directory) if you need separate pending indexes.
+ *
  * Decision settled for Phase 2: invalid edited arguments (failing validation
  * against the tool's declared schema) do NOT throw and do NOT re-suspend for
  * correction. They're normalized into a REJECTED outcome with a reason describing

--- a/src/main/bx/models/hitl/HumanInteractionCoordinator.bx
+++ b/src/main/bx/models/hitl/HumanInteractionCoordinator.bx
@@ -342,6 +342,21 @@ class {
 	}
 
 	/**
+	 * Look up the currently-pending suspension for a thread, if any. Built on getAllPending()
+	 * rather than a separate index — no new durable state, just a query over what's already
+	 * tracked as pending. Returns null if the thread has nothing pending — including if it
+	 * once did and has since been resolved; this only reports current, actionable state, not
+	 * history (use getDecision() against a known suspensionID for that).
+	 *
+	 * @threadID The thread to look up
+	 */
+	AgentSuspension function getSuspensionByThread( required string threadID ) {
+		var targetThreadID = arguments.threadID
+		var matches         = getAllPending().filter( ( suspension ) => suspension.getThreadID() == targetThreadID )
+		return matches.isEmpty() ? javacast( "null", "" ) : matches.first()
+	}
+
+	/**
 	 * Remove a suspension entirely — from the durable index, its own durable entry, and
 	 * this coordinator's in-memory structs. Distinct from resolve(): this doesn't require
 	 * or record a decision, it just forgets the suspension ever existed. Intended for

--- a/src/main/bx/models/hitl/HumanInteractionCoordinator.bx
+++ b/src/main/bx/models/hitl/HumanInteractionCoordinator.bx
@@ -46,6 +46,20 @@
  * processes racing) — each instance's compare-and-set is only atomic within itself.
  * Treat cross-process concurrent resolution as out of scope for this phase.
  *
+ * Bulk/durable lookups (hasPending/getAllPending/clearSuspension/clearAllPending): backed
+ * by a single well-known checkpointer key (see pendingIndexKey()) holding every currently-
+ * pending suspensionID, rather than a real prefix-scan of the checkpointer — deliberately,
+ * since IAiMemory has no such capability and most backends don't durably persist
+ * saveState/loadState/clearState at all beyond Cache/File/Jdbc. That single key is
+ * read-modified-written on every create/resolve/clear, so two processes racing on it can
+ * each miss the other's update. The failure mode is self-correcting for false positives
+ * (a stale "still pending" entry — getAllPending() re-checks each suspension's actual
+ * persisted status before returning it, and the atomic claim in resolve() still prevents
+ * a real double-resolve regardless). It is NOT self-correcting for a false negative — a
+ * suspension whose creation crashed between persistSuspension() and addToPendingIndex()
+ * would never appear in getAllPending() at all. Treat that as out of scope for this phase,
+ * same as the cross-process atomicity gap above.
+ *
  * Decision settled for Phase 2: invalid edited arguments (failing validation
  * against the tool's declared schema) do NOT throw and do NOT re-suspend for
  * correction. They're normalized into a REJECTED outcome with a reason describing
@@ -189,6 +203,7 @@ class {
 			"threadID": arguments.threadID
 		}
 		persistSuspension( suspension.getSuspensionID() )
+		addToPendingIndex( suspension.getSuspensionID() )
 
 		if ( len( toolName ) && isAlreadyGranted( identity, arguments.threadID, toolName ) ) {
 			var autoDecision = new HumanInteractionDecision(
@@ -280,8 +295,59 @@ class {
 		}
 
 		persistSuspension( arguments.suspensionID )
+		removeFromPendingIndex( arguments.suspensionID )
 
 		return suspension
+	}
+
+	/**
+	 * Whether a suspension is currently tracked as pending in the durable index. Cheap —
+	 * checks the index only, without hydrating the full suspension. False for an unknown
+	 * id, a resolved suspension, or when no checkpointer is linked (nothing durable to
+	 * check — falls back to false rather than an in-memory-only guess).
+	 *
+	 * @suspensionID The suspension id to check
+	 */
+	boolean function hasPending( required string suspensionID ) {
+		var targetID = arguments.suspensionID
+		return !loadPendingIndex().filter( ( id ) => id == targetID ).isEmpty()
+	}
+
+	/**
+	 * Every currently-pending suspension, per the durable index. Hydrates any suspension
+	 * not already in memory (same as getSuspension()), then re-checks each one's actual
+	 * persisted status before including it — the index can go stale (see class docs), the
+	 * suspension's own status is the real source of truth.
+	 *
+	 * @return Array of pending AgentSuspension instances
+	 */
+	array function getAllPending() {
+		return loadPendingIndex()
+			.map( ( id ) => getSuspension( id ) )
+			.filter( ( suspension ) => !isNull( suspension ) && suspension.isPending() )
+	}
+
+	/**
+	 * Remove a suspension entirely — from the durable index, its own durable entry, and
+	 * this coordinator's in-memory structs. Distinct from resolve(): this doesn't require
+	 * or record a decision, it just forgets the suspension ever existed. Intended for
+	 * administrative cleanup (an expired or abandoned request), not a human decision path.
+	 *
+	 * @suspensionID The suspension to clear
+	 */
+	void function clearSuspension( required string suspensionID ) {
+		clearSuspensionEntry( arguments.suspensionID )
+		removeFromPendingIndex( arguments.suspensionID )
+	}
+
+	/**
+	 * Clear every currently-pending suspension — see clearSuspension(). An administrative
+	 * bulk reset (tests, or an operator flushing a stuck queue), not a decision path.
+	 */
+	void function clearAllPending() {
+		var ids = loadPendingIndex()
+		ids.each( ( id ) => clearSuspensionEntry( id ) )
+		savePendingIndex( [] )
 	}
 
 	/**
@@ -490,6 +556,91 @@ class {
 	 */
 	private string function persistenceKey( required string suspensionID ) {
 		return "hitl:suspension:" & arguments.suspensionID
+	}
+
+	/**
+	 * The single, well-known checkpointer key the durable pending-suspension index is
+	 * stored under. See class docs for why this is one key rather than a real prefix-scan.
+	 */
+	private string function pendingIndexKey() {
+		return "hitl:pending-index"
+	}
+
+	/**
+	 * Load the current durable set of pending suspensionIDs. Always reads straight from
+	 * the checkpointer rather than caching in memory — these bulk operations exist
+	 * specifically to see durable, possibly cross-process state. Empty array when no
+	 * checkpointer is linked or nothing has been indexed yet.
+	 */
+	private array function loadPendingIndex() {
+		if ( isNull( variables.checkpointer ) ) {
+			return []
+		}
+		var saved = variables.checkpointer.loadState( pendingIndexKey() )
+		return saved.ids ?: []
+	}
+
+	/**
+	 * Persist the given set of pending suspensionIDs as the durable index. A no-op when no
+	 * checkpointer is linked.
+	 *
+	 * @ids The full set of currently-pending suspensionIDs to persist
+	 */
+	private void function savePendingIndex( required array ids ) {
+		if ( isNull( variables.checkpointer ) ) {
+			return
+		}
+		variables.checkpointer.saveState( pendingIndexKey(), { "ids": arguments.ids } )
+	}
+
+	/**
+	 * Add a suspensionID to the durable pending index. A no-op when no checkpointer is
+	 * linked, or it's already present.
+	 *
+	 * @suspensionID The suspension to add
+	 */
+	private void function addToPendingIndex( required string suspensionID ) {
+		if ( isNull( variables.checkpointer ) ) {
+			return
+		}
+		var targetID = arguments.suspensionID
+		var ids      = loadPendingIndex()
+		if ( ids.filter( ( id ) => id == targetID ).isEmpty() ) {
+			ids.append( targetID )
+			savePendingIndex( ids )
+		}
+	}
+
+	/**
+	 * Remove a suspensionID from the durable pending index. A no-op when no checkpointer
+	 * is linked.
+	 *
+	 * @suspensionID The suspension to remove
+	 */
+	private void function removeFromPendingIndex( required string suspensionID ) {
+		if ( isNull( variables.checkpointer ) ) {
+			return
+		}
+		var targetID = arguments.suspensionID
+		savePendingIndex( loadPendingIndex().filter( ( id ) => id != targetID ) )
+	}
+
+	/**
+	 * Delete a single suspension's own durable entry and in-memory bookkeeping — everything
+	 * except its membership in the pending index, which clearSuspension()/clearAllPending()
+	 * handle separately (clearAllPending() batches the index write into one, rather than
+	 * once per suspension).
+	 *
+	 * @suspensionID The suspension entry to delete
+	 */
+	private void function clearSuspensionEntry( required string suspensionID ) {
+		if ( !isNull( variables.checkpointer ) ) {
+			variables.checkpointer.clearState( persistenceKey( arguments.suspensionID ) )
+		}
+		variables.suspensions.delete( arguments.suspensionID )
+		variables.decisions.delete( arguments.suspensionID )
+		variables.suspensionMeta.delete( arguments.suspensionID )
+		variables.statusLocks.remove( arguments.suspensionID )
 	}
 
 	/**

--- a/src/main/bx/models/middleware/core/HumanInTheLoopMiddleware.bx
+++ b/src/main/bx/models/middleware/core/HumanInTheLoopMiddleware.bx
@@ -74,6 +74,7 @@ import bxModules.bxai.models.hitl.decisions.IDecisionStore;
 import bxModules.bxai.models.hitl.policies.ToolNameApprovalPolicy;
 import bxModules.bxai.models.hitl.policies.CallbackApprovalPolicy;
 import bxModules.bxai.models.gateway.IGateway;
+import bxModules.bxai.models.gateway.AgentSuspension;
 import bxModules.bxai.models.gateway.cli.CliGateway;
 import bxModules.bxai.models.gateway.contracts.GatewayContext;
 import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
@@ -229,6 +230,63 @@ class extends="BaseAiMiddleware" {
 					"Pass checkpointer: to aiAgent(...) so a pending approval can survive past this run."
 			)
 		}
+	}
+
+	// ==================== Coordinator delegates ====================
+	//
+	// Thin pass-throughs to this middleware's HumanInteractionCoordinator, so callers
+	// don't need to reach through getCoordinator() themselves for common lookups. All the
+	// actual logic and durability live on HumanInteractionCoordinator — see its docs.
+
+	/**
+	 * Look up a tracked suspension by id, pending or resolved.
+	 *
+	 * @suspensionID The suspension id to look up
+	 */
+	AgentSuspension function getSuspension( required string suspensionID ) {
+		return variables.coordinator.getSuspension( arguments.suspensionID )
+	}
+
+	/**
+	 * Look up the decision a suspension was resolved with, if any.
+	 *
+	 * @suspensionID The suspension id to look up
+	 */
+	HumanInteractionDecision function getDecision( required string suspensionID ) {
+		return variables.coordinator.getDecision( arguments.suspensionID )
+	}
+
+	/**
+	 * Whether a suspension is currently tracked as pending.
+	 *
+	 * @suspensionID The suspension id to check
+	 */
+	boolean function hasPending( required string suspensionID ) {
+		return variables.coordinator.hasPending( arguments.suspensionID )
+	}
+
+	/**
+	 * Every currently-pending suspension.
+	 */
+	array function getAllPending() {
+		return variables.coordinator.getAllPending()
+	}
+
+	/**
+	 * Remove a suspension entirely — without recording a decision. Distinct from resolving
+	 * it; see HumanInteractionCoordinator.clearSuspension().
+	 *
+	 * @suspensionID The suspension to clear
+	 */
+	void function clearSuspension( required string suspensionID ) {
+		variables.coordinator.clearSuspension( arguments.suspensionID )
+	}
+
+	/**
+	 * Clear every currently-pending suspension.
+	 */
+	void function clearAllPending() {
+		variables.coordinator.clearAllPending()
 	}
 
 	// ==================== Hooks ====================

--- a/src/main/bx/models/middleware/core/HumanInTheLoopMiddleware.bx
+++ b/src/main/bx/models/middleware/core/HumanInTheLoopMiddleware.bx
@@ -273,6 +273,16 @@ class extends="BaseAiMiddleware" {
 	}
 
 	/**
+	 * Look up the currently-pending suspension for a thread, if any — e.g. to check whether
+	 * there's something awaiting a decision before calling agent.resume(decision, threadId).
+	 *
+	 * @threadID The thread to look up
+	 */
+	AgentSuspension function getSuspensionByThread( required string threadID ) {
+		return variables.coordinator.getSuspensionByThread( arguments.threadID )
+	}
+
+	/**
 	 * Remove a suspension entirely — without recording a decision. Distinct from resolving
 	 * it; see HumanInteractionCoordinator.clearSuspension().
 	 *

--- a/src/test/java/ortus/boxlang/ai/hitl/HumanInteractionCoordinatorTest.java
+++ b/src/test/java/ortus/boxlang/ai/hitl/HumanInteractionCoordinatorTest.java
@@ -720,4 +720,58 @@ public class HumanInteractionCoordinatorTest extends BaseIntegrationTest {
 		assertThat( variables.getAsBoolean( Key.of( "didNotThrow" ) ) ).isTrue();
 	}
 
+	// ---- getSuspensionByThread() ----
+
+	@DisplayName( "getSuspensionByThread(): finds the pending suspension for a thread among several others" )
+	@Test
+	public void testGetSuspensionByThread() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.hitl.HumanInteractionCoordinator;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionDecision;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				// Isolated File-backed store — see testHasPendingAndGetAllPendingLifecycle()
+				// for why aiMemory("cache") isn't safe for count/identity-sensitive assertions
+				// like this one when run alongside other cache-backed HITL tests.
+				cp = aiMemory( memory: "file", config: { directoryPath: getTempDirectory() & "/bxai-hitl-by-thread-" & createUUID() } )
+				coordinator = new HumanInteractionCoordinator()
+				coordinator.setCheckpointer( cp )
+				gw = aiGateway( "mock" )
+
+				ctxA = new GatewayContext( gateway: "mock", threadID: "thread-A" )
+				ctxB = new GatewayContext( gateway: "mock", threadID: "thread-B" )
+				reqA = new HumanInteractionRequest( executionID: "run-A" )
+				reqB = new HumanInteractionRequest( executionID: "run-B" )
+
+				sA = coordinator.requestApproval( humanRequest: reqA, context: ctxA, gateway: gw, threadID: "thread-A" )
+				sB = coordinator.requestApproval( humanRequest: reqB, context: ctxB, gateway: gw, threadID: "thread-B" )
+
+				foundA = coordinator.getSuspensionByThread( "thread-A" )
+				matchesA = !isNull( foundA ) && foundA.getSuspensionID() == sA.getSuspensionID()
+
+				// A thread with nothing pending at all
+				nothingForUnknownThread = isNull( coordinator.getSuspensionByThread( "thread-nonexistent" ) )
+
+				// A thread whose suspension has since been resolved is no longer "pending" —
+				// getSuspensionByThread() should stop finding it
+				decision = new HumanInteractionDecision( requestID: reqA.getId(), decision: "approve" )
+				coordinator.resolve( sA.getSuspensionID(), decision )
+				goneAfterResolve = isNull( coordinator.getSuspensionByThread( "thread-A" ) )
+
+				// thread-B is untouched and still findable
+				stillFindsB = coordinator.getSuspensionByThread( "thread-B" ).getSuspensionID() == sB.getSuspensionID()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "matchesA" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "nothingForUnknownThread" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "goneAfterResolve" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "stillFindsB" ) ) ).isTrue();
+	}
+
 }

--- a/src/test/java/ortus/boxlang/ai/hitl/HumanInteractionCoordinatorTest.java
+++ b/src/test/java/ortus/boxlang/ai/hitl/HumanInteractionCoordinatorTest.java
@@ -559,7 +559,14 @@ public class HumanInteractionCoordinatorTest extends BaseIntegrationTest {
 				import bxModules.bxai.models.gateway.contracts.HumanInteractionDecision;
 				import bxModules.bxai.models.gateway.contracts.GatewayContext;
 
-				cp = aiMemory( "cache" )
+				// File-backed with a unique directory, not aiMemory("cache") — CacheMemory's
+				// saveState/loadState key by threadId alone ("checkpoint:" & threadId), not
+				// scoped by its own instance key, so every aiMemory("cache") in the same JVM
+				// shares one checkpoint keyspace. The pending index uses one fixed key
+				// ("hitl:pending-index"), so two coordinators sharing that keyspace — e.g. this
+				// test running alongside any other cache-backed HITL test — would corrupt each
+				// other's counts. A unique directory per test genuinely isolates it.
+				cp = aiMemory( memory: "file", config: { directoryPath: getTempDirectory() & "/bxai-hitl-index-lifecycle-" & createUUID() } )
 
 				coord1 = new HumanInteractionCoordinator()
 				coord1.setCheckpointer( cp )
@@ -650,7 +657,10 @@ public class HumanInteractionCoordinatorTest extends BaseIntegrationTest {
 				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
 				import bxModules.bxai.models.gateway.contracts.GatewayContext;
 
-				cp = aiMemory( "cache" )
+				// See testHasPendingAndGetAllPendingLifecycle() for why this is File-backed with
+				// a unique directory rather than aiMemory("cache") — clearAllPending() here would
+				// otherwise wipe out any other cache-backed coordinator's pending index too.
+				cp = aiMemory( memory: "file", config: { directoryPath: getTempDirectory() & "/bxai-hitl-clear-all-" & createUUID() } )
 				coordinator = new HumanInteractionCoordinator()
 				coordinator.setCheckpointer( cp )
 				gw = aiGateway( "mock" )

--- a/src/test/java/ortus/boxlang/ai/hitl/HumanInteractionCoordinatorTest.java
+++ b/src/test/java/ortus/boxlang/ai/hitl/HumanInteractionCoordinatorTest.java
@@ -546,4 +546,168 @@ public class HumanInteractionCoordinatorTest extends BaseIntegrationTest {
 		assertThat( variables.getAsBoolean( Key.of( "decisionSurvived" ) ) ).isTrue();
 	}
 
+	// ---- Durable pending index: hasPending() / getAllPending() / clearSuspension() / clearAllPending() ----
+
+	@DisplayName( "hasPending()/getAllPending(): reflect the index across create, resolve, and a fresh instance" )
+	@Test
+	public void testHasPendingAndGetAllPendingLifecycle() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.hitl.HumanInteractionCoordinator;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionDecision;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				cp = aiMemory( "cache" )
+
+				coord1 = new HumanInteractionCoordinator()
+				coord1.setCheckpointer( cp )
+				gw = aiGateway( "mock" )
+				ctx = new GatewayContext( gateway: "mock", threadID: "index-thread" )
+
+				req1 = new HumanInteractionRequest( executionID: "run-index-1" )
+				req2 = new HumanInteractionRequest( executionID: "run-index-2" )
+
+				s1 = coord1.requestApproval( humanRequest: req1, context: ctx, gateway: gw, threadID: "index-thread-1" )
+				s2 = coord1.requestApproval( humanRequest: req2, context: ctx, gateway: gw, threadID: "index-thread-2" )
+
+				bothPendingOnCoord1 = coord1.hasPending( s1.getSuspensionID() ) && coord1.hasPending( s2.getSuspensionID() )
+				allPendingCountAfterCreate = coord1.getAllPending().len()
+
+				// A fresh instance — same checkpointer, nothing in memory — sees the same index
+				coord2 = new HumanInteractionCoordinator()
+				coord2.setCheckpointer( cp )
+				sameCountFromFreshInstance = coord2.getAllPending().len() == 2
+				coord2HasBoth = coord2.hasPending( s1.getSuspensionID() ) && coord2.hasPending( s2.getSuspensionID() )
+
+				// Resolving one removes it from the index — visible from either instance
+				decision = new HumanInteractionDecision( requestID: req1.getId(), decision: "approve" )
+				coord2.resolve( s1.getSuspensionID(), decision )
+
+				stillHasS2NotS1 = !coord2.hasPending( s1.getSuspensionID() ) && coord2.hasPending( s2.getSuspensionID() )
+				countAfterOneResolved = coord1.getAllPending().len()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "bothPendingOnCoord1" ) ) ).isTrue();
+		assertThat( variables.getAsInteger( Key.of( "allPendingCountAfterCreate" ) ) ).isEqualTo( 2 );
+		assertThat( variables.getAsBoolean( Key.of( "sameCountFromFreshInstance" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "coord2HasBoth" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "stillHasS2NotS1" ) ) ).isTrue();
+		assertThat( variables.getAsInteger( Key.of( "countAfterOneResolved" ) ) ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "clearSuspension(): removes it from the index, its durable entry, and memory — without recording a decision" )
+	@Test
+	public void testClearSuspension() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.hitl.HumanInteractionCoordinator;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				cp = aiMemory( "cache" )
+				coordinator = new HumanInteractionCoordinator()
+				coordinator.setCheckpointer( cp )
+				gw = aiGateway( "mock" )
+				ctx = new GatewayContext( gateway: "mock", threadID: "clear-thread" )
+
+				req = new HumanInteractionRequest( executionID: "run-clear" )
+				suspension = coordinator.requestApproval( humanRequest: req, context: ctx, gateway: gw, threadID: "clear-thread" )
+				id = suspension.getSuspensionID()
+
+				pendingBeforeClear = coordinator.hasPending( id )
+				coordinator.clearSuspension( id )
+				pendingAfterClear = coordinator.hasPending( id )
+				goneFromGetSuspension = isNull( coordinator.getSuspension( id ) )
+
+				// A fresh instance shouldn't be able to hydrate it either — it's really gone
+				coord2 = new HumanInteractionCoordinator()
+				coord2.setCheckpointer( cp )
+				goneFromFreshInstance = isNull( coord2.getSuspension( id ) )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "pendingBeforeClear" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "pendingAfterClear" ) ) ).isFalse();
+		assertThat( variables.getAsBoolean( Key.of( "goneFromGetSuspension" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "goneFromFreshInstance" ) ) ).isTrue();
+	}
+
+	@DisplayName( "clearAllPending(): removes every pending suspension in one call" )
+	@Test
+	public void testClearAllPending() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.hitl.HumanInteractionCoordinator;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				cp = aiMemory( "cache" )
+				coordinator = new HumanInteractionCoordinator()
+				coordinator.setCheckpointer( cp )
+				gw = aiGateway( "mock" )
+				ctx = new GatewayContext( gateway: "mock", threadID: "clear-all-thread" )
+
+				ids = []
+				for ( i = 1; i <= 3; i++ ) {
+					req = new HumanInteractionRequest( executionID: "run-clear-all-" & i )
+					s = coordinator.requestApproval( humanRequest: req, context: ctx, gateway: gw, threadID: "clear-all-thread-" & i )
+					ids.append( s.getSuspensionID() )
+				}
+
+				countBeforeClear = coordinator.getAllPending().len()
+				coordinator.clearAllPending()
+				countAfterClear = coordinator.getAllPending().len()
+				noneStillPending = ids.filter( ( id ) => coordinator.hasPending( id ) ).isEmpty()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsInteger( Key.of( "countBeforeClear" ) ) ).isEqualTo( 3 );
+		assertThat( variables.getAsInteger( Key.of( "countAfterClear" ) ) ).isEqualTo( 0 );
+		assertThat( variables.getAsBoolean( Key.of( "noneStillPending" ) ) ).isTrue();
+	}
+
+	@DisplayName( "without setCheckpointer(): hasPending()/getAllPending()/clearAllPending() are safe no-ops, not errors" )
+	@Test
+	public void testPendingIndexOperationsSafeWithoutCheckpointer() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.hitl.HumanInteractionCoordinator;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				coordinator = new HumanInteractionCoordinator()
+				gw = aiGateway( "mock" )
+				ctx = new GatewayContext( gateway: "mock", threadID: "no-cp-index-thread" )
+				req = new HumanInteractionRequest( executionID: "run-no-cp-index" )
+
+				suspension = coordinator.requestApproval( humanRequest: req, context: ctx, gateway: gw, threadID: "no-cp-index-thread" )
+
+				didNotThrow = true
+				try {
+					hasIt   = coordinator.hasPending( suspension.getSuspensionID() )
+					allPend = coordinator.getAllPending()
+					coordinator.clearAllPending()
+				} catch ( any e ) {
+					didNotThrow = false
+				}
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "didNotThrow" ) ) ).isTrue();
+	}
+
 }

--- a/src/test/java/ortus/boxlang/ai/middleware/HumanInTheLoopGatewayTest.java
+++ b/src/test/java/ortus/boxlang/ai/middleware/HumanInTheLoopGatewayTest.java
@@ -591,4 +591,35 @@ public class HumanInTheLoopGatewayTest extends BaseIntegrationTest {
 		assertThat( variables.getAsBoolean( Key.of( "noneLeftAfterClearAll" ) ) ).isTrue();
 	}
 
+	@DisplayName( "getSuspensionByThread(): delegate reaches the same coordinator state as calling it directly" )
+	@Test
+	public void testGetSuspensionByThreadDelegate() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.middleware.core.HumanInTheLoopMiddleware;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				gw = aiGateway( "mock" )
+				mw = new HumanInTheLoopMiddleware( toolsRequiringApproval: [ "placeOrder" ], gateway: gw )
+				mw.getCoordinator().setCheckpointer( aiMemory( memory: "file", config: { directoryPath: getTempDirectory() & "/bxai-hitl-mw-by-thread-" & createUUID() } ) )
+
+				req = new HumanInteractionRequest( executionID: "run-by-thread-delegate" )
+				ctx = new GatewayContext( gateway: "mock", threadID: "delegate-by-thread" )
+				suspension = mw.getCoordinator().requestApproval( humanRequest: req, context: ctx, gateway: gw, threadID: "delegate-by-thread" )
+
+				viaDelegate    = mw.getSuspensionByThread( "delegate-by-thread" )
+				viaCoordinator = mw.getCoordinator().getSuspensionByThread( "delegate-by-thread" )
+				sameSuspension = !isNull( viaDelegate ) && viaDelegate.getSuspensionID() == viaCoordinator.getSuspensionID()
+				nothingForOtherThread = isNull( mw.getSuspensionByThread( "some-other-thread" ) )
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "sameSuspension" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "nothingForOtherThread" ) ) ).isTrue();
+	}
+
 }

--- a/src/test/java/ortus/boxlang/ai/middleware/HumanInTheLoopGatewayTest.java
+++ b/src/test/java/ortus/boxlang/ai/middleware/HumanInTheLoopGatewayTest.java
@@ -530,4 +530,65 @@ public class HumanInTheLoopGatewayTest extends BaseIntegrationTest {
 		assertThat( variables.getAsBoolean( Key.of( "gatewayGotIt" ) ) ).isTrue();
 	}
 
+	@DisplayName( "coordinator delegates: getSuspension/getDecision/hasPending/getAllPending/clearSuspension/clearAllPending all pass through" )
+	@Test
+	public void testCoordinatorDelegates() {
+		// @formatter:off
+		runtime.executeSource(
+			"""
+				import bxModules.bxai.models.middleware.core.HumanInTheLoopMiddleware;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionRequest;
+				import bxModules.bxai.models.gateway.contracts.HumanInteractionDecision;
+				import bxModules.bxai.models.gateway.contracts.GatewayContext;
+
+				gw = aiGateway( "mock" )
+				mw = new HumanInTheLoopMiddleware( toolsRequiringApproval: [ "placeOrder" ], gateway: gw )
+				// hasPending()/getAllPending() read the durable index, which only exists once a
+				// checkpointer is linked — normally onAttach() does this; standalone here, so link
+				// it directly on the coordinator. File-backed with a unique directory, not
+				// aiMemory("cache") — CacheMemory's saveState/loadState key by threadId alone,
+				// not scoped by its own instance key, so every aiMemory("cache") in the same JVM
+				// shares one checkpoint keyspace; the pending index's one fixed key would then
+				// collide with any other cache-backed HITL test running in the same suite.
+				mw.getCoordinator().setCheckpointer( aiMemory( memory: "file", config: { directoryPath: getTempDirectory() & "/bxai-hitl-mw-delegates-" & createUUID() } ) )
+				ctx = new GatewayContext( gateway: "mock", threadID: "delegate-thread" )
+
+				req1 = new HumanInteractionRequest( executionID: "run-delegate-1" )
+				req2 = new HumanInteractionRequest( executionID: "run-delegate-2" )
+				s1 = mw.getCoordinator().requestApproval( humanRequest: req1, context: ctx, gateway: gw, threadID: "delegate-thread-1" )
+				s2 = mw.getCoordinator().requestApproval( humanRequest: req2, context: ctx, gateway: gw, threadID: "delegate-thread-2" )
+				id1 = s1.getSuspensionID()
+				id2 = s2.getSuspensionID()
+
+				// getSuspension()/hasPending()/getAllPending() reach the same coordinator state
+				// as calling getCoordinator() directly
+				sameSuspension = mw.getSuspension( id1 ) == mw.getCoordinator().getSuspension( id1 )
+				hasPendingViaDelegate = mw.hasPending( id1 )
+				allPendingViaDelegate = mw.getAllPending().len() == 2
+
+				// getDecision(): resolve directly on the coordinator, read back via the delegate
+				decision = new HumanInteractionDecision( requestID: req1.getId(), decision: "approve" )
+				mw.getCoordinator().resolve( id1, decision )
+				decisionViaDelegate = mw.getDecision( id1 ).isApproved()
+
+				// clearSuspension(): via the delegate, confirm gone from the coordinator too
+				mw.clearSuspension( id2 )
+				goneAfterDelegateClear = isNull( mw.getCoordinator().getSuspension( id2 ) )
+
+				// clearAllPending(): nothing pending left either way (id1 already resolved, id2 cleared)
+				mw.clearAllPending()
+				noneLeftAfterClearAll = mw.getAllPending().isEmpty()
+			""",
+			context
+		);
+		// @formatter:on
+
+		assertThat( variables.getAsBoolean( Key.of( "sameSuspension" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "hasPendingViaDelegate" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "allPendingViaDelegate" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "decisionViaDelegate" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "goneAfterDelegateClear" ) ) ).isTrue();
+		assertThat( variables.getAsBoolean( Key.of( "noneLeftAfterClearAll" ) ) ).isTrue();
+	}
+
 }


### PR DESCRIPTION
## Description

Adds a durable, checkpointer-backed "pending interaction index" to `HumanInteractionCoordinator`, giving a complete get-one / check-one / clear-one / get-all / clear-all surface for pending suspensions:

- `getSuspension(id)` — get one (already existed)
- `hasPending(id)` — check one, cheap index-only check without a full hydrate
- `getAllPending()` — get all currently-pending suspensions
- `clearSuspension(id)` — clear one (removes it entirely — index, durable entry, and memory — without recording a decision, distinct from `resolve()`)
- `clearAllPending()` — clear all, in one batched index write

All backed by the same `IAiMemory`-shaped checkpointer this module already wires through `HumanInTheLoopMiddleware.onAttach()`, under one well-known key (`hitl:pending-index`) rather than a real prefix-scan of the store.

**Design note (documented in the class docs):** went with a single indexed key rather than extending `IAiMemory` with a `listKeys()`/scan() capability. The latter would mean touching every memory backend in the module — most of which don't durably persist `saveState`/`loadState` at all today (only Cache/File/Jdbc override `BaseMemory`'s in-process-only default) — for a capability only HITL needs. The index stays entirely inside HITL's own code and reuses the exact `saveState`/`loadState` surface already integrated.

`requestApproval()` adds to the index; `resolve()`/`clearSuspension()`/`clearAllPending()` remove from it. `getAllPending()` re-checks each suspension's actual persisted status before returning it, since the index itself is a single read-modify-written blob and can go stale under concurrent writers — a false positive (stale "still pending" entry) self-corrects on the next check; a false negative (a suspension whose creation crashed between being persisted and being indexed) does not. Both are called out explicitly in the class docs as an accepted limitation, same category as the existing cross-process atomic-claim caveat.

Also fixes a real closure-scoping bug caught while writing tests for this: `arguments.x` referenced inside a `.filter()`/`.map()` closure resolves to the *closure's own* arguments (its declared param plus positional index/array from the filter/map call), not the enclosing function's `arguments` scope. Three of the four new private helpers hit this on the first pass. Fixed by capturing the value into a local variable ahead of the closure instead. Checked every other file touched in this line of work for the same pattern — none found.

## Type of change

-   [ ] Bug Fix
-   [x] Improvement
-   [x] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml) — followed existing file conventions by hand; the formatter itself wasn't run
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

## Test plan

- [x] `./gradlew shadowJar` builds clean
- [x] New tests: full pending-index lifecycle across create/resolve and a fresh coordinator instance sharing one checkpointer; `clearSuspension()` removing a suspension entirely (verified even a fresh instance can't find it afterward); `clearAllPending()` across multiple suspensions in one call; every new method confirmed as a safe no-op when no checkpointer is linked
- [x] Full relevant sweep (`middleware`, `hitl`, `gateway`, `runnables`, `registry`, `memory.CacheMemoryTest`, `memory.FileMemoryTest`) — 335 tests, only the same 12 pre-existing/unrelated failures (missing real OpenAI API key in this sandbox), no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQv4kirCUu4G8aG9aMqEoE)_