### PR TITLE
Make Cohere/HuggingFace tests non-blocking in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
           # Download BoxLang and other dependencies
           ./gradlew downloadBoxLang
           # this is done in order to build the module structure before testing
-          ./gradlew shadowJar test --stacktrace --console=plain
+          ./gradlew shadowJar test testOptionalProviders --stacktrace --console=plain
 
       - name: Upload Test Results
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,25 @@ test {
         showCauses true
 	}
 	classpath = classpath.filter { !it.path.contains( "build${File.separator}resources" ) }
+	exclude '**/CohereTest.class', '**/HuggingFaceTest.class'
+}
+
+// Cohere/HuggingFace tests hit live external APIs and are currently unstable;
+// run them in their own task with ignoreFailures so they don't block the build.
+task testOptionalProviders( type: Test ) {
+	description = "Runs Cohere/HuggingFace provider tests without failing the build"
+    useJUnitPlatform()
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath.filter { !it.path.contains( "build${File.separator}resources" ) }
+	include '**/CohereTest.class', '**/HuggingFaceTest.class'
+    testLogging {
+		showStandardStreams = true
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+        showExceptions true
+        showCauses true
+	}
+	ignoreFailures = true
 }
 
 /**


### PR DESCRIPTION
Split CohereTest/HuggingFaceTest into a separate testOptionalProviders
Gradle task with ignoreFailures=true, since they call live external
APIs and are currently unstable. The main test task now excludes
them and stays strict, so those two providers no longer block the
whole build while other test failures still fail CI as before.