### PR TITLE
Make the live Bedrock tests region-portable, hermetic and non-blocking

### DIFF
--- a/src/test/java/ortus/boxlang/ai/BaseIntegrationTest.java
+++ b/src/test/java/ortus/boxlang/ai/BaseIntegrationTest.java
@@ -17,6 +17,8 @@ package ortus.boxlang.ai;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.junit.jupiter.api.Assumptions.abort;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -36,12 +38,22 @@ import ortus.boxlang.runtime.services.ModuleService;
  */
 public abstract class BaseIntegrationTest {
 
-	protected static Dotenv					dotenv		= Dotenv.load();
+	protected static Dotenv					dotenv						= Dotenv.load();
+
+	/**
+	 * Live-Bedrock model ids, overridable via .env. Defaults are "global." inference profiles
+	 * deliberately: in us-east-1 the only on-demand Anthropic *foundation* model is the 2024
+	 * claude-3-haiku, so any current model is reachable only through a profile, and a
+	 * region-prefixed one ("eu."/"us.") pins the suite to one region. A global profile resolves
+	 * in every region. Shared here so a deprecation is a one-line change, not a two-file hunt.
+	 */
+	protected static final String			BEDROCK_MODEL				= dotenv.get( "BEDROCK_MODEL", "global.anthropic.claude-haiku-4-5-20251001-v1:0" );
+	protected static final String			BEDROCK_STRUCTURED_MODEL	= dotenv.get( "BEDROCK_STRUCTURED_MODEL", "global.anthropic.claude-sonnet-4-6" );
 	protected static BoxRuntime				runtime;
 	protected static ModuleService			moduleService;
 	protected static ModuleRecord			moduleRecord;
-	protected static Key					result		= new Key( "result" );
-	protected static Key					moduleName	= new Key( "bxai" );
+	protected static Key					result						= new Key( "result" );
+	protected static Key					moduleName					= new Key( "bxai" );
 	protected ScriptingRequestBoxContext	context;
 	protected IScope						variables;
 
@@ -127,6 +139,70 @@ public abstract class BaseIntegrationTest {
 				return false;
 			}
 			// Re-throw other exceptions
+			throw e;
+		}
+	}
+
+	/**
+	 * getSystemSetting() resolves against BOTH System.getenv() and System.getProperties(), and
+	 * BoxLang structs are case-insensitive — so a test asserting "no credential is configured"
+	 * cannot just read System.getenv( NAME ) and call it settled.
+	 */
+	protected static boolean hasAmbientSetting( String name ) {
+		if ( System.getProperty( name ) != null ) {
+			return true;
+		}
+		return System.getenv().keySet().stream().anyMatch( k -> k.equalsIgnoreCase( name ) )
+		    || System.getProperties().keySet().stream().anyMatch( k -> String.valueOf( k ).equalsIgnoreCase( name ) );
+	}
+
+	/**
+	 * Markers that describe the ENVIRONMENT: this account/role cannot make the call at all.
+	 * Deliberately absent: "InvalidSignatureException" (SigV4 canonicalization regressed) and
+	 * "ValidationException" — Bedrock returns the latter for a malformed request body, bad
+	 * parameters, or an unknown model id, which is exactly what a request-transform regression
+	 * looks like. Keying on the 403 status instead would be wrong: AWS returns 403 for
+	 * InvalidSignatureException too, so a SigV4 regression would be tolerated as an entitlement
+	 * problem. Those must fail the build.
+	 */
+	private static final String[] LIVE_CALL_ENVIRONMENT_MARKERS = {
+	    // no entitlement / wrong or unusable principal
+	    "accessdenied", "unrecognizedclient", "don't have access", "not authorized",
+	    // an SSO/STS session token that has aged out is the most common local-dev case, and
+	    // "expired" is a different string from "invalid" — matching only the latter missed it
+	    "security token included in the request is invalid", "security token included in the request is expired",
+	    "expiredtoken",
+	    // the CI matrix runs os x jdk jobs in parallel against one Bedrock account, so
+	    // per-account InvokeModel TPS is reachable; the module has real 429 handling elsewhere
+	    "throttling", "too many requests"
+	};
+
+	/**
+	 * executeWithTimeoutHandling() tolerates only timeouts and re-throws everything else, so a
+	 * model this account has not enabled — or a role without bedrock:InvokeModel — turns a live
+	 * smoke test into a hard build failure. Those are environment facts, not regressions: skip.
+	 *
+	 * @return the same contract as executeWithTimeoutHandling(): false if a timeout was caught
+	 *         and swallowed, so callers must skip assertions depending on the source's output.
+	 */
+	protected boolean executeLiveBedrockCall( String source, IBoxContext context ) {
+		try {
+			return executeWithTimeoutHandling( source, context );
+		} catch ( Exception e ) {
+			// The provider inlines the raw AWS body into the message, but an async path can wrap
+			// it, so walk the cause chain rather than reading only the outermost message.
+			for ( Throwable t = e; t != null; t = t.getCause() ) {
+				String message = t.getMessage();
+				if ( message == null ) {
+					continue;
+				}
+				String haystack = message.toLowerCase();
+				for ( String marker : LIVE_CALL_ENVIRONMENT_MARKERS ) {
+					if ( haystack.contains( marker ) ) {
+						abort( "Bedrock live call unavailable for these credentials: " + message );
+					}
+				}
+			}
 			throw e;
 		}
 	}

--- a/src/test/java/ortus/boxlang/ai/providers/BedrockServiceTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/BedrockServiceTest.java
@@ -19,7 +19,6 @@ package ortus.boxlang.ai.providers;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assumptions.abort;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.ai.BaseIntegrationTest;
-import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
@@ -101,31 +99,6 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 		return !awsAccessKeyId.isEmpty() && !awsSecretAccessKey.isEmpty();
 	}
 
-	/**
-	 * executeWithTimeoutHandling() tolerates only timeouts and re-throws everything else, so a
-	 * model this account has not enabled — or a role without bedrock:InvokeModel — turns a live
-	 * smoke test into a hard build failure. Those are environment facts, not regressions: skip.
-	 */
-	private void executeLiveBedrockCall( String source, IBoxContext context ) {
-		try {
-			executeWithTimeoutHandling( source, context );
-		} catch ( Exception e ) {
-			String message = String.valueOf( e.getMessage() );
-			// Tolerated markers describe the ENVIRONMENT: this account/role cannot make the call.
-			// Deliberately NOT tolerated: "InvalidSignatureException" (SigV4 canonicalization
-			// regressed) and "ValidationException" — Bedrock returns the latter for a malformed
-			// request body, bad parameters, or an unknown model id, which is exactly what a
-			// regression in the request transform looks like. Those must fail the build.
-			for ( String marker : new String[] { "AccessDenied", "AccessDeniedException", "UnrecognizedClient", "don't have access",
-			    "not authorized", "security token included in the request is invalid" } ) {
-				if ( message.contains( marker ) ) {
-					abort( "Bedrock live call unavailable for these credentials: " + message );
-				}
-			}
-			throw e;
-		}
-	}
-
 	@Test
 	@DisplayName( "Can instantiate Bedrock service via aiService BIF" )
 	public void testInstantiateBedrock() {
@@ -180,13 +153,13 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 		assumeTrue( hasAwsCredentials(), "AWS credentials not configured in .env" );
 
 		// @formatter:off
-		executeLiveBedrockCall(
+		assumeTrue( executeLiveBedrockCall(
 			"""
 				// aiChat signature: invoke(messages, params, options, headers)
 				response = aiChat(
 					aiMessage().user( "Say 'Bedrock test successful' and nothing else" ),
 					{
-						model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+						model: "%s",
 						max_tokens: 100
 					},
 					{
@@ -196,9 +169,9 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 				)
 
 				hasContent = !isNull( response )
-			""",
+			""".formatted( BEDROCK_MODEL ),
 			context
-		);
+		), "live Bedrock call timed out" );
 		// @formatter:on
 
 		assertThat( variables.get( Key.of( "hasContent" ) ) ).isEqualTo( true );
@@ -1489,7 +1462,7 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 		// configure(string) keeps its original, non-breaking meaning: set modelId. See
 		// BedrockService.configure()'s docblock for why Bedrock deliberately deviates from
 		// BaseService's "string = apiKey" contract here.
-		assumeTrue( System.getenv( "AWS_BEARER_TOKEN_BEDROCK" ) == null, "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
+		assumeTrue( !hasAmbientSetting( "AWS_BEARER_TOKEN_BEDROCK" ), "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
 
 		// @formatter:off
 		executeWithTimeoutHandling(
@@ -1518,7 +1491,7 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 		// no AWS credentials configured must NOT have that string silently selected as a Bedrock
 		// bearer token. Bearer auth only activates via the explicit bearerToken key or the
 		// AWS_BEARER_TOKEN_BEDROCK env var (guarded below).
-		assumeTrue( System.getenv( "AWS_BEARER_TOKEN_BEDROCK" ) == null, "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
+		assumeTrue( !hasAmbientSetting( "AWS_BEARER_TOKEN_BEDROCK" ), "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
 
 		// @formatter:off
 		executeWithTimeoutHandling(
@@ -1537,7 +1510,10 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 	@Test
 	@DisplayName( "useBearerAuth() is true when an explicit bearerToken is configured and no AWS access key is available" )
 	public void testExplicitBearerTokenUsesBearerAuth() {
-		assumeTrue( System.getenv( "AWS_BEARER_TOKEN_BEDROCK" ) == null, "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
+		assumeTrue( !hasAmbientSetting( "AWS_BEARER_TOKEN_BEDROCK" ), "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
+		// loadAwsCredentialsFromEnvironment() picks up an ambient AWS_ACCESS_KEY_ID, and useBearerAuth()
+		// short-circuits to false on any access key — so this assertion only holds without one.
+		assumeTrue( !hasAmbientSetting( "AWS_ACCESS_KEY_ID" ), "AWS_ACCESS_KEY_ID is set in the ambient environment" );
 
 		// @formatter:off
 		executeWithTimeoutHandling(
@@ -1562,7 +1538,7 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 		// the explicit awsAccessKeyId passed below, variables.awsAccessKeyId can end up empty if
 		// dotenv has no real AWS creds — at that point this assertion depends solely on the
 		// ambient AWS_BEARER_TOKEN_BEDROCK env var being unset.
-		assumeTrue( System.getenv( "AWS_BEARER_TOKEN_BEDROCK" ) == null, "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
+		assumeTrue( !hasAmbientSetting( "AWS_BEARER_TOKEN_BEDROCK" ), "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
 
 		// @formatter:off
 		executeWithTimeoutHandling(
@@ -1589,7 +1565,7 @@ public class BedrockServiceTest extends BaseIntegrationTest {
 		// the struct-credentials flow doesn't accidentally end up in bearer mode. When dotenv has
 		// no real AWS creds, variables.awsAccessKeyId ends up empty too, so this assertion falls
 		// through to depending on the ambient AWS_BEARER_TOKEN_BEDROCK env var being unset.
-		assumeTrue( System.getenv( "AWS_BEARER_TOKEN_BEDROCK" ) == null, "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
+		assumeTrue( !hasAmbientSetting( "AWS_BEARER_TOKEN_BEDROCK" ), "AWS_BEARER_TOKEN_BEDROCK is set in the ambient environment" );
 
 		// @formatter:off
 		executeWithTimeoutHandling(

--- a/src/test/java/ortus/boxlang/ai/providers/BedrockTest.java
+++ b/src/test/java/ortus/boxlang/ai/providers/BedrockTest.java
@@ -15,7 +15,9 @@
 package ortus.boxlang.ai.providers;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,24 +31,38 @@ import ortus.boxlang.runtime.types.Struct;
  *
  * These hit real Bedrock and are skipped unless AWS credentials are present in
  * the environment (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION, and
- * AWS_SESSION_TOKEN for SSO). The model must also be enabled in that
- * account/region — note that newer Claude models are only reachable on-demand
- * via an inference-profile id (e.g. "us.anthropic.claude-3-5-sonnet-...");
- * adjust BEDROCK_MODEL to one your test account can invoke.
+ * AWS_SESSION_TOKEN for SSO). A call this account/role simply cannot make —
+ * no entitlement, an expired session token, throttling — is skipped rather
+ * than failed; see BaseIntegrationTest::executeLiveBedrockCall.
+ *
+ * The model must also be enabled in that account/region. Both ids are
+ * overridable from .env, defined in BaseIntegrationTest:
+ *
+ * <pre>
+ * BEDROCK_MODEL=...             # plain chat and tool-use
+ * BEDROCK_STRUCTURED_MODEL=...  # structured output via forced tool-use
+ * </pre>
+ *
+ * The defaults are "global." inference profiles so they resolve in any region.
+ * Override BEDROCK_MODEL only with a model that supports tool use — the
+ * tool-use test shares it, and Bedrock answers a model that does not with a
+ * ValidationException, which is deliberately NOT tolerated.
  *
  * For deterministic, credential-free coverage of the tool-use logic see
  * BedrockToolUseTest.
  */
 public class BedrockTest extends BaseIntegrationTest {
 
-	private static final String	BEDROCK_MODEL				= "anthropic.claude-3-5-sonnet-20240620-v1:0";
-	// Cross-region inference profile id reachable in eu-west-2 for structured-output coverage
-	private static final String	BEDROCK_STRUCTURED_MODEL	= "eu.anthropic.claude-sonnet-4-6";
+	private String	awsAccessKeyId;
+	private String	awsSecretAccessKey;
+	private String	awsSessionToken;
+	private String	awsRegion;
 
-	private String				awsAccessKeyId;
-	private String				awsSecretAccessKey;
-	private String				awsSessionToken;
-	private String				awsRegion;
+	private boolean	captured;
+	private boolean	hadPriorProvider;
+	private Object	priorProvider;
+	private boolean	hadPriorApiKey;
+	private Object	priorApiKey;
 
 	@BeforeEach
 	public void beforeEach() {
@@ -56,6 +72,15 @@ public class BedrockTest extends BaseIntegrationTest {
 		awsSecretAccessKey	= dotenv.get( "AWS_SECRET_ACCESS_KEY", "" );
 		awsSessionToken		= dotenv.get( "AWS_SESSION_TOKEN", "" );
 		awsRegion			= dotenv.get( "AWS_REGION", "us-east-1" );
+
+		// moduleRecord.settings is static and shared with every other test class in this Gradle
+		// worker, and Bedrock is the only provider whose apiKey is a struct — leaking it makes
+		// setApiKeyIfEmpty( required string ) throw a type error in whichever class runs next.
+		hadPriorProvider	= moduleRecord.settings.containsKey( "provider" );
+		priorProvider		= moduleRecord.settings.get( "provider" );
+		hadPriorApiKey		= moduleRecord.settings.containsKey( "apiKey" );
+		priorApiKey			= moduleRecord.settings.get( "apiKey" );
+		captured			= true;
 
 		moduleRecord.settings.put( "provider", "bedrock" );
 		Struct credentials = new Struct();
@@ -68,6 +93,25 @@ public class BedrockTest extends BaseIntegrationTest {
 		moduleRecord.settings.put( "apiKey", credentials );
 	}
 
+	@AfterEach
+	public void afterEach() {
+		// A @BeforeEach that threw before the capture leaves the flags false — restoring then would
+		// delete shared settings this class never wrote. JUnit runs @AfterEach either way.
+		if ( !captured ) {
+			return;
+		}
+		if ( hadPriorProvider ) {
+			moduleRecord.settings.put( "provider", priorProvider );
+		} else {
+			moduleRecord.settings.remove( "provider" );
+		}
+		if ( hadPriorApiKey ) {
+			moduleRecord.settings.put( "apiKey", priorApiKey );
+		} else {
+			moduleRecord.settings.remove( "apiKey" );
+		}
+	}
+
 	private boolean hasAwsCredentials() {
 		return !awsAccessKeyId.isEmpty() && !awsSecretAccessKey.isEmpty();
 	}
@@ -75,20 +119,17 @@ public class BedrockTest extends BaseIntegrationTest {
 	@DisplayName( "Test Bedrock AI chat" )
 	@Test
 	public void testBedrock() {
-		if ( !hasAwsCredentials() ) {
-			System.out.println( "Skipping testBedrock - AWS credentials not configured in .env" );
-			return;
-		}
+		assumeTrue( hasAwsCredentials(), "AWS credentials not configured in .env" );
 
 		// @formatter:off
-		executeWithTimeoutHandling(
+		assumeTrue( executeLiveBedrockCall(
 			"""
 			result    = aiChat( messages = "what is boxlang?", options = { model: "%s" } )
 			answerLen = len( result )
 			println( result )
 			""".formatted( BEDROCK_MODEL ),
 			context
-		);
+		), "live Bedrock call timed out" );
 		// @formatter:on
 
 		assertThat( variables.get( Key.of( "result" ) ) ).isInstanceOf( String.class );
@@ -98,13 +139,10 @@ public class BedrockTest extends BaseIntegrationTest {
 	@DisplayName( "Test Bedrock Tools" )
 	@Test
 	public void testBedrockTools() {
-		if ( !hasAwsCredentials() ) {
-			System.out.println( "Skipping testBedrockTools - AWS credentials not configured in .env" );
-			return;
-		}
+		assumeTrue( hasAwsCredentials(), "AWS credentials not configured in .env" );
 
 		// @formatter:off
-		executeWithTimeoutHandling(
+		assumeTrue( executeLiveBedrockCall(
 			"""
 			tool = aiTool(
 				"get_weather",
@@ -128,7 +166,7 @@ public class BedrockTest extends BaseIntegrationTest {
 			println( result )
 			""".formatted( BEDROCK_MODEL ),
 			context
-		);
+		), "live Bedrock call timed out" );
 		// @formatter:on
 
 		assertThat( variables.get( Key.of( "result" ) ) ).isEqualTo( "San Salvador" );
@@ -137,13 +175,10 @@ public class BedrockTest extends BaseIntegrationTest {
 	@DisplayName( "Test Bedrock structured output via forced tool-use" )
 	@Test
 	public void testBedrockStructuredOutput() {
-		if ( !hasAwsCredentials() ) {
-			System.out.println( "Skipping testBedrockStructuredOutput - AWS credentials not configured in .env" );
-			return;
-		}
+		assumeTrue( hasAwsCredentials(), "AWS credentials not configured in .env" );
 
 		// @formatter:off
-		executeWithTimeoutHandling(
+		assumeTrue( executeLiveBedrockCall(
 			"""
 			result = aiChat(
 				messages = "John Doe is 30 years old and lives in Seattle. Extract his details.",
@@ -168,7 +203,7 @@ public class BedrockTest extends BaseIntegrationTest {
 			println( result )
 			""".formatted( BEDROCK_STRUCTURED_MODEL ),
 			context
-		);
+		), "live Bedrock call timed out" );
 		// @formatter:on
 
 		assertThat( variables.getAsBoolean( Key.of( "isStruct" ) ) ).isTrue();


### PR DESCRIPTION
Test-only follow-up to #233, found by running its live tests against a real **eu-west-2** account. The merged Bedrock code is fine — everything here is test-side. No product code is touched, and no changelog entry, matching #261.

The suite only passed on a us-east-1 account that happened to have no AWS credentials in the environment.

### Model ids were pinned to a us-only model

Both ids were hardcoded to `anthropic.claude-3-5-sonnet-*`, which isn't offered in eu-west-2 at all:

```
aws bedrock list-foundation-models --region eu-west-2 \
  --query "modelSummaries[?contains(modelId,'claude-3-5-sonnet')]"
→ []
```

so every live call returned `400 The provided model identifier is invalid`. They now live in `BaseIntegrationTest` — one env key, one home — overridable as `BEDROCK_MODEL` and `BEDROCK_STRUCTURED_MODEL`.

The defaults are **`global.` inference profiles**, deliberately. In us-east-1 the only on-demand Anthropic *foundation* model is the 2024 `claude-3-haiku`, so anything current is reachable only through a profile — and a region-prefixed profile (`eu.`/`us.`) just re-pins the suite to one region, which is the bug being fixed. A `global.` profile resolves in every region and tracks a current model. Both defaults were confirmed invokable by direct `converse` call.

### Environment facts now skip instead of breaking the build

`BedrockServiceTest` had a private `executeLiveBedrockCall` that skipped on entitlement errors; `BedrockTest` had nothing, so an identical 403 skipped in one class and failed the build in the other. That helper is promoted to `BaseIntegrationTest` and `BedrockTest`'s three live call sites use it.

The deliberate exclusions are kept: **`InvalidSignatureException` (SigV4) and `ValidationException` (request transform) still fail hard.** Worth recording why this is marker-matching and not a status-code check — AWS returns 403 for `InvalidSignatureException` too, so keying on the status would silently tolerate a SigV4 regression.

Additions to the tolerated set, both real conditions this suite will meet:
- an **expired** STS/SSO session token — `"expired"` is a different string from `"invalid"`, and an aged-out token is the normal local-dev state
- **throttling** — the `os × jdkVersion` matrix runs in parallel against one Bedrock account, and the module has dedicated `onAIRateLimitHit` handling, so a 429 is designed-for rather than a regression

Matching is now case-insensitive, null-safe, and walks the cause chain (an async path can wrap the AWS body), consistent with `isTimeoutException` in the same class. The helper also returns `executeWithTimeoutHandling`'s boolean instead of swallowing it, so its documented "skip assertions after a swallowed timeout" contract survives — as a `void` wrapper it had quietly opted the four Bedrock live tests out of the timeout tolerance #261 established everywhere else.

### Two tests that reported green without testing anything

- Three tests did `if ( !hasAwsCredentials() ) { println; return; }`. An early `return` is **PASSED**, not skipped — so with no `.env` they reported green while exercising nothing. Now `assumeTrue`.
- `testExplicitBearerTokenUsesBearerAuth` asserts `useBearerAuth()` is true "when no AWS access key is available" but guarded only on `AWS_BEARER_TOKEN_BEDROCK`. `loadAwsCredentialsFromEnvironment()` picks up an ambient `AWS_ACCESS_KEY_ID` and `useBearerAuth()` short-circuits on any access key, so it failed for anyone with credentials exported. It now guards via `hasAmbientSetting()`, which checks env vars **and** system properties case-insensitively — the same channels `getSystemSetting()` itself resolves against, where `System.getenv` alone is too narrow.

### Shared static settings leak

`moduleRecord.settings` is `static`, shared by every test class in a Gradle worker. Bedrock is the only provider whose `apiKey` is a struct, and `setApiKeyIfEmpty()` declares `required string apiKey` — so leaking it makes the next class die with `argument [apiKey] with a type of [Struct] does not match the declared type of [string]`. `BedrockServiceTest` already captured and restored; `BedrockTest` overwrote both keys and never restored. It now does, gated on a flag so a `beforeEach` that throws before the capture can't delete settings this class never wrote.

Observed concretely against #249's `OutputGuardMiddlewareTest`, which shares the worker: 9 of its 14 tests failed on that type error before, all 14 pass after.

**Known and deliberately left:** ~38 other classes mutate that shared struct without restoring. Fixing it centrally in `BaseIntegrationTest` is the right depth, but needs a *deep* copy — three sites in `BedrockServiceTest` mutate nested structs in place, which a shallow snapshot would restore by reference while appearing complete — and it changes behaviour for ~114 subclasses at once. Separate work.

### Verification

Against real Bedrock, three ways:

| run | `BedrockTest` | `BedrockServiceTest` |
|---|---|---|
| credentials, **no** model overrides | **3 pass, 0 fail** | 62, 0 fail, 1 skip |
| every `AWS_*` unset | 0 fail, 3 clean skips | 62, 0 fail, 1 skip |
| full suite | **147 failures vs a 150 baseline** | — |

The full-suite delta is exactly the three Bedrock live tests moving from failing to skipping — same test count, three failures became three skips, nothing else changed. The credentialed run uses the committed defaults with no `.env` help, which is what makes it evidence about the defaults rather than about an override.

Conflict-free with #249 in either merge order (`git merge-tree` clean both ways), so no ordering constraint between them.
