### PR TITLE
fix: MCPRequestProcessor parameter collides with its own MCPServer import (regression of #191)

### DIFF
--- a/src/main/bx/models/mcp/MCPRequestProcessor.bx
+++ b/src/main/bx/models/mcp/MCPRequestProcessor.bx
@@ -367,7 +367,7 @@ class {
 	 * Handle CORS preflight requests
 	 *
 	 * @response The response struct to populate
-	 * @mcpServer The MCP server instance for CORS configuration
+	 * @targetServer The MCP server instance for CORS configuration
 	 *
 	 * @return The populated response struct
 	 */
@@ -388,19 +388,19 @@ class {
 	/**
 	 * Handle GET requests for server discovery
 	 *
-	 * @mcpServer The MCP server instance
+	 * @targetServer The MCP server instance
 	 * @response The response struct to populate
 	 * @urlParams URL parameters
 	 *
 	 * @return The populated response struct
 	 */
-	private static  struct function handleDiscovery( required any mcpServer, required struct response, struct urlParams = {} ) {
+	private static  struct function handleDiscovery( required any targetServer, required struct response, struct urlParams = {} ) {
 		arguments.response.content = {
 			"jsonrpc": "2.0",
 			"result": {
 				"protocolVersion": static.DEFAULT_MCP_PROTOCOL_VERSION,
-				"capabilities": arguments.mcpServer.getCapabilities(),
-				"serverInfo": arguments.mcpServer.getServerInfo()
+				"capabilities": arguments.targetServer.getCapabilities(),
+				"serverInfo": arguments.targetServer.getServerInfo()
 			},
 			"id": arguments.urlParams.id ?: javacast( "null", "" )
 		}.toJson()
@@ -411,7 +411,7 @@ class {
 	/**
 	 * Handle POST requests for JSON-RPC
 	 *
-	 * @mcpServer The MCP server instance
+	 * @targetServer The MCP server instance
 	 * @response The response struct to populate
 	 * @requestBody The request body
 	 * @acceptHeader The Accept header value
@@ -419,7 +419,7 @@ class {
 	 * @return The populated response struct
 	 */
 	private static  struct function handleJSONRPC(
-		required any mcpServer,
+		required any targetServer,
 		required struct response,
 		required string requestBody,
 		string acceptHeader = "application/json"
@@ -429,7 +429,7 @@ class {
 			var useSSE = arguments.acceptHeader contains "text/event-stream";
 
 			// Process the MCP request
-			var mcpResponse = arguments.mcpServer.handleRequest( arguments.requestBody );
+			var mcpResponse = arguments.targetServer.handleRequest( arguments.requestBody );
 
 			// Format response
 			if ( useSSE ) {


### PR DESCRIPTION
## The bug

`MCPRequestProcessor.handleDiscovery()` and `handleJSONRPC()` take a parameter named `mcpServer`, while line 27 of the same file has:

```
import bxModules.bxai.models.mcp.MCPServer;
```

BoxLang identifiers are case-insensitive, so those are the same name and the class does not compile:

```
You cannot use a function parameter with the same name as an import: [mcpServer]
position: .../models/mcp/MCPRequestProcessor.bx: 397,50 - 397,72
```

## Why it matters

`MCPRequestProcessor` is on the path of every HTTP MCP request, so on any consumer that loads this module the MCP transport is **dead, not degraded** — every call fails at class load. There is no partial failure mode and nothing logs a cause that points at the module.

I hit this deploying `development` into a BoxLang Lambda: the module passed the consuming project's full unit suite and a clean gradle build first, because `.bx` files ship as resources and nothing compiled them until production did.

Not version-specific — reproduced on **1.14.0+55** and **1.16.0+53**. A four-line repro (`import java.util.HashMap;` plus a parameter named `hashMap`) is rejected by both, so the compiler check is long-standing.

## This is a regression, not a new bug

- **#191** (`418e0bb`, 2026-05-30) — *"fix: rename mcpServer param to targetServer to resolve import collision"*. Same bug, same fix, same rename.
- **#238** (`c7f0a4b`, 2026-08-04) — *"Rename remaining reserved-scope-named identifiers for hygiene (Phase 2)"* renamed `server` → `mcpServer` and reintroduced it.

#238 was right in intent: `server` genuinely is a reserved scope. It just traded a scope collision for the import collision #191 had already removed. Nothing guarded the fix, so it came back three months later.

## The fix

Renames the parameter to `targetServer` — which is already this file's own name for the same object:

```
var targetServer = MCPServer::getInstance( mcpServerName );   // :194
...
response = handleDiscovery( targetServer, response, urlParams );   // :332
```

Signature-compatible: all three call sites (`:245`, `:332`, `:336`) pass positionally and none used named arguments. `mcpServerName` is a distinct identifier and is deliberately untouched. Also fixes `handleCORSPreflight`'s docblock, which documented `@mcpServer` while its parameter has been `targetServer` all along — the #238 sweep renamed the doc and missed the signature.

## Verification

```
$ bx compile --source lambda/boxlang_modules --target /tmp/x
✅ Successful:    205        ❌ Failed:        0

# same tree with this fix reverted
❌ FAILED FILES
1. .../bx-ai/models/mcp/MCPRequestProcessor.bx
```

A scan of `src/main/bx` finds no other parameter shadowing an import.

## Suggestion

Given this has now regressed once, a `bx compile --source src/main/bx` step in CI would be worth more than either fix on its own — it catches this whole class (import shadowing, reserved-scope parameters, unclosed braces, bad static references) rather than one instance. I added exactly that gate downstream after this incident; happy to open a separate PR here if useful.
