### PR TITLE
Bump default AI request timeout from 45s to 90s

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🧠 Updated
 
+- Default AI request timeout (`settings.timeout`) bumped from 45 to 90 seconds. A timed-out HTTP call surfaces as a confusing `JsonDeserializationError` ("Failed to parse JSON... Request Timeout") rather than a clear timeout error, and 45s was too tight for slower providers/models under load; raising the default reduces intermittent failures for CLI/`.bxs` usage. Still overridable per-request via `options.timeout` or per-provider via `settings.providers.<name>.options.timeout`.
 - OpenAI provider's default chat model bumped from `gpt-5-nano` to `gpt-5.6-luna`.
 - Claude provider's default chat model bumped from `claude-sonnet-4-5` to `claude-sonnet-5`.
 - `SummaryMemory`: `maxMessages` now triggers compression and `summaryThreshold` is the keep-window (previously threshold did both and `maxMessages` was unused).

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ Below is the full reference of every setting you can place under `settings` in `
                     }
                 },
 
-                "timeout": 45,
+                "timeout": 90,
 
                 "logRequest": false,
                 "logRequestToConsole": false,
@@ -149,7 +149,7 @@ Below is the full reference of every setting you can place under `settings` in `
 | `memory.provider` | `string` | `"window"` | Default memory type: `window`, `cache`, `file`, `session`, `summary`, `jdbc`, `hybrid`, or any vector provider |
 | `memory.config` | `struct` | `{}` | Provider-specific memory configuration (e.g. `maxMessages`, `cacheName`) |
 | `providers` | `struct` | `{}` | Per-provider overrides — keys are provider names, values have `params` and `options` structs |
-| `timeout` | `numeric` | `45` | Default HTTP request timeout in seconds |
+| `timeout` | `numeric` | `90` | Default HTTP request timeout in seconds |
 | `logRequest` | `boolean` | `false` | Log outgoing AI requests to `ai.log` |
 | `logRequestToConsole` | `boolean` | `false` | Print outgoing AI requests to the console (useful for debugging) |
 | `logResponse` | `boolean` | `false` | Log AI responses to `ai.log` |

--- a/src/main/bx/ModuleConfig.bx
+++ b/src/main/bx/ModuleConfig.bx
@@ -126,7 +126,7 @@ class {
 				// }
 			},
 			// The default timeout of the ai requests
-			timeout : 45,
+			timeout : 90,
 			// If true, the AI request will be logged into the ai.log
 			logRequest : false,
 			// If true, the AI request will be logged to the console

--- a/src/main/bx/bifs/aiChat.bx
+++ b/src/main/bx/bifs/aiChat.bx
@@ -45,7 +45,7 @@ class {
 	 * <ul>
 	 * <li>provider:string - The provider to use for the chat. If not passed, we will use the default from the configuration.</li>
 	 * <li>apiKey:string - The API Key for the provider. If not passed, we will use the default from the configuration.</li>
-	 * <li>timeout:numeric - The timeout in seconds for the request. The default is 30 seconds</li>
+	 * <li>timeout:numeric - The timeout in seconds for the request. The default is 90 seconds</li>
 	 * <li>logResponse:boolean - Log the response into the ai.log. The default is false</li>
 	 * <li>logResponseToConsole:boolean - Log the response to the console. The default is false</li>
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>

--- a/src/main/bx/bifs/aiChatAsync.bx
+++ b/src/main/bx/bifs/aiChatAsync.bx
@@ -37,7 +37,7 @@ class extends="aiChat"{
 	 * <ul>
 	 * <li>provider:string - The provider to use for the chat. If not passed, we will use the default from the configuration.</li>
 	 * <li>apiKey:string - The API Key for the provider. If not passed, we will use the default from the configuration.</li>
-	 * <li>timeout:numeric - The timeout in seconds for the request. The default is 30 seconds</li>
+	 * <li>timeout:numeric - The timeout in seconds for the request. The default is 90 seconds</li>
 	 * <li>logResponse:boolean - Log the response into the ai.log. The default is false</li>
 	 * <li>logResponseToConsole:boolean - Log the response to the console. The default is false</li>
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>

--- a/src/main/bx/bifs/aiChatStream.bx
+++ b/src/main/bx/bifs/aiChatStream.bx
@@ -50,7 +50,7 @@ class {
 	 * <ul>
 	 * <li>provider:string - The provider to use for the chat. If not passed, we will use the default from the configuration.</li>
 	 * <li>apiKey:string - The API Key for the provider. If not passed, we will use the default from the configuration.</li>
-	 * <li>timeout:numeric - The timeout in seconds for the request. The default is 30 seconds</li>
+	 * <li>timeout:numeric - The timeout in seconds for the request. The default is 90 seconds</li>
 	 * <li>logResponse:boolean - Log the response into the ai.log. The default is false</li>
 	 * <li>logResponseToConsole:boolean - Log the response to the console. The default is false</li>
 	 * <li>logRequest:boolean - Log the request into the ai.log. The default is false</li>


### PR DESCRIPTION
# Description

A client reported intermittent `Error deserializing response from provider: Failed to parse JSON... Request Timeout` when running `.bxs` scripts from the command line, with the same prompt sometimes succeeding. Root cause: the HTTP call to the provider was timing out at the module's default of 45s, the timed-out response body (`Request Timeout`) was then fed into `jsonDeserialize()`, and the resulting parse error masked the real cause (a timeout, not malformed JSON).

45 seconds is tight for slower providers/models under load (long completions, big context, reasoning models, cold starts), so this raises the module-wide default `timeout` setting from 45 to 90 seconds. This is a config/documentation change only — the timeout was already fully configurable (per-request via `options.timeout`, or per-provider via `settings.providers.<name>.options.timeout`); this just raises the out-of-the-box default so fewer users hit the confusing error before discovering the setting exists.

Changes:
- `ModuleConfig.bx`: default `settings.timeout` 45 → 90
- `readme.md`: settings reference table and example config updated to match
- `aiChat.bx` / `aiChatAsync.bx` / `aiChatStream.bx`: fixed stale docblocks that said the default was 30 seconds (it was already 45 via module settings merge; now 90)
- `changelog.md`: entry under Unreleased / Updated

## Jira/Github Issues

N/A — small default-value/documentation change requested directly by a client conversation, no tracked issue.

## Type of change

-   [ ] Bug Fix
-   [x] Improvement
-   [ ] New Feature
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have commented my code, particularly in hard-to-understand areas (n/a — no logic changed, only a default value and docs)
-   [x] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works (n/a — no behavior/logic to test, a default constant changed; no existing test asserted the old literal value)
-   [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01A16zwu9YhTSFL3xg1Br97w)_