### PR TITLE
build: pin BoxLang 1.17.0, require >= 1.14.0

### DIFF
--- a/box.json
+++ b/box.json
@@ -17,7 +17,7 @@
 		"boxlang"
 	],
 	"boxlang": {
-		"minimumVersion": "1.8.0",
+		"minimumVersion": "1.14.0",
 		"moduleName": "bxai"
 	},
 	"private": false,

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Migration
+
+- **Minimum BoxLang runtime is now 1.14.0** (`box.json` `minimumVersion`, previously 1.8.0). BoxLang ≤1.13 resolves unqualified identifiers inside a `catch` body against the class `variables` scope before locals and `arguments`; 1.14.0 fixed this. The module still qualifies its own catch reads, but middleware, tools, and interceptors authored against this module should not rely on older runtimes. The build now compiles and tests against 1.17.0.
+
 ## [3.4.0] - 2026-09-01
 
 ### 🥊 Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Tue Sep 01 04:28:00 UTC 2026
 sqliteModuleVersion=1.2.0
 webSupportVersion=1.1.1
-boxlangVersion=1.13.0
+boxlangVersion=1.17.0
 derbyModuleVersion=1.1.0
 postgresqlModuleVersion=1.1.0
 mysqlModuleVersion=1.0.1

--- a/src/test/java/ortus/boxlang/ai/BaseIntegrationTest.java
+++ b/src/test/java/ortus/boxlang/ai/BaseIntegrationTest.java
@@ -26,6 +26,7 @@ import io.github.cdimascio.dotenv.Dotenv;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.modules.BoxModuleConfig;
 import ortus.boxlang.runtime.modules.ModuleRecord;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
@@ -87,7 +88,7 @@ public abstract class BaseIntegrationTest {
 
 			// Execute the onRuntimeStart() lifecycle method to ensure tools are registered
 			// Since we are lazy loading the module
-			moduleRecord.moduleConfig.dereferenceAndInvoke(
+			( ( BoxModuleConfig ) moduleRecord.moduleConfig ).getBxClass().dereferenceAndInvoke(
 			    context,
 			    Key.of( "onRuntimeStart" ),
 			    new Object[] {},


### PR DESCRIPTION
## Summary
Build-only. Pins the test runtime to BoxLang **1.17.0** (`gradle.properties`, was 1.13.0) and raises `box.json` `minimumVersion` from 1.8.0 to **1.14.0**.

**Why:** BoxLang ≤ 1.13 resolves an unqualified identifier inside a `catch` body against the class `variables` scope *before* function locals and `arguments` (instance vars, properties and method names all shadow). Fixed upstream in 1.14.0; verified with a 7-case repro on 1.13.0 (broken) and 1.14.0 / 1.17.0 / 1.17.3 (clean). 1.17.0 is the newest 1.17.x with both a `-snapshot` and a release jar published, which the build's branch-based suffix logic needs.

**Only compile break:** `ModuleRecord.moduleConfig` is now a `BoxModuleConfig` wrapper, so `BaseIntegrationTest` reaches the class runnable via `getBxClass()`.

## Tests
Smoke on 1.17.0-snapshot: BedrockServiceTest 70, SuspendResume 22, coreMiddleware 17, FlightRecorder 14 all pass; ClaudeTest's 7 live-key cases fail as on `development`.

## Relation to other PRs
Independent. Part of the split of #271 / #273 requested by @lmajano; the sibling PRs (#170, #198, #248, #272) each stand alone against `development` and were tested on both 1.13 and 1.17.
